### PR TITLE
[REVIEW] Rename sample packages to use an @azure-samples namespace

### DIFF
--- a/common/tools/dev-tool/src/util/samples/generation.ts
+++ b/common/tools/dev-tool/src/util/samples/generation.ts
@@ -27,7 +27,7 @@ const log = createPrinter("generator");
 export function createPackageJson(info: SampleGenerationInfo, outputKind: OutputKind): unknown {
   const fullOutputKind = outputKind === OutputKind.TypeScript ? "TypeScript" : "JavaScript";
   return {
-    name: `azure-${info.baseName}-samples-${outputKind}${info.isBeta ? "-beta" : ""}`,
+    name: `@azure-samples/${info.baseName}-${outputKind}${info.isBeta ? "-beta" : ""}`,
     private: true,
     version: "1.0.0",
     description: `${info.productName} client library samples for ${fullOutputKind}${

--- a/sdk/agrifood/agrifood-farming-rest/samples/v1/javascript/package.json
+++ b/sdk/agrifood/agrifood-farming-rest/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-agrifood-farming-samples-js",
+  "name": "@azure-samples/agrifood-farming-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure FarmBeats rest client library samples for JavaScript",

--- a/sdk/agrifood/agrifood-farming-rest/samples/v1/javascript/package.json
+++ b/sdk/agrifood/agrifood-farming-rest/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/agrifood-farming-samples-js",
+  "name": "@azure-samples/agrifood-farming-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure FarmBeats rest client library samples for JavaScript",

--- a/sdk/agrifood/agrifood-farming-rest/samples/v1/typescript/package.json
+++ b/sdk/agrifood/agrifood-farming-rest/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-agrifood-farming-samples-ts",
+  "name": "@azure-samples/agrifood-farming-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure FarmBeats rest client library samples for TypeScript",

--- a/sdk/agrifood/agrifood-farming-rest/samples/v1/typescript/package.json
+++ b/sdk/agrifood/agrifood-farming-rest/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/agrifood-farming-samples-ts",
+  "name": "@azure-samples/agrifood-farming-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure FarmBeats rest client library samples for TypeScript",

--- a/sdk/anomalydetector/ai-anomaly-detector/samples/v3/javascript/package.json
+++ b/sdk/anomalydetector/ai-anomaly-detector/samples/v3/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-ai-anomaly-detector-samples-js",
+  "name": "@azure-samples/ai-anomaly-detector-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Data Tables client library samples for JavaScript",

--- a/sdk/anomalydetector/ai-anomaly-detector/samples/v3/javascript/package.json
+++ b/sdk/anomalydetector/ai-anomaly-detector/samples/v3/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/ai-anomaly-detector-samples-js",
+  "name": "@azure-samples/ai-anomaly-detector-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Data Tables client library samples for JavaScript",

--- a/sdk/anomalydetector/ai-anomaly-detector/samples/v3/typescript/package.json
+++ b/sdk/anomalydetector/ai-anomaly-detector/samples/v3/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/ai-anomaly-detector-samples-ts",
+  "name": "@azure-samples/ai-anomaly-detector-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Data Tables client library samples for TypeScript",

--- a/sdk/anomalydetector/ai-anomaly-detector/samples/v3/typescript/package.json
+++ b/sdk/anomalydetector/ai-anomaly-detector/samples/v3/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-ai-anomaly-detector-samples-ts",
+  "name": "@azure-samples/ai-anomaly-detector-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Data Tables client library samples for TypeScript",

--- a/sdk/app/arm-app/samples/v1-beta/javascript/package.json
+++ b/sdk/app/arm-app/samples/v1-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-app-samples-js-beta",
+  "name": "@azure-samples/arm-app-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/app/arm-app/samples/v1-beta/javascript/package.json
+++ b/sdk/app/arm-app/samples/v1-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-app-samples-js-beta",
+  "name": "@azure-samples/arm-app-samples-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/app/arm-app/samples/v1-beta/typescript/package.json
+++ b/sdk/app/arm-app/samples/v1-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-app-samples-ts-beta",
+  "name": "@azure-samples/arm-app-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/app/arm-app/samples/v1-beta/typescript/package.json
+++ b/sdk/app/arm-app/samples/v1-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-app-samples-ts-beta",
+  "name": "@azure-samples/arm-app-samples-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/appconfiguration/app-configuration/samples/v1/javascript/package.json
+++ b/sdk/appconfiguration/app-configuration/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/app-configuration-samples-js",
+  "name": "@azure-samples/app-configuration-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure App Configuration client library samples for JavaScript",

--- a/sdk/appconfiguration/app-configuration/samples/v1/javascript/package.json
+++ b/sdk/appconfiguration/app-configuration/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-app-configuration-samples-js",
+  "name": "@azure-samples/app-configuration-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure App Configuration client library samples for JavaScript",

--- a/sdk/appconfiguration/app-configuration/samples/v1/typescript/package.json
+++ b/sdk/appconfiguration/app-configuration/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/app-configuration-samples-ts",
+  "name": "@azure-samples/app-configuration-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure App Configuration client library samples for TypeScript",

--- a/sdk/appconfiguration/app-configuration/samples/v1/typescript/package.json
+++ b/sdk/appconfiguration/app-configuration/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-app-configuration-samples-ts",
+  "name": "@azure-samples/app-configuration-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure App Configuration client library samples for TypeScript",

--- a/sdk/appconfiguration/arm-appconfiguration/samples/v1-beta/javascript/package.json
+++ b/sdk/appconfiguration/arm-appconfiguration/samples/v1-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-appconfiguration-samples-js-beta",
+  "name": "@azure-samples/arm-appconfiguration-samples-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/appconfiguration/arm-appconfiguration/samples/v1-beta/javascript/package.json
+++ b/sdk/appconfiguration/arm-appconfiguration/samples/v1-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-appconfiguration-samples-js-beta",
+  "name": "@azure-samples/arm-appconfiguration-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/appconfiguration/arm-appconfiguration/samples/v1-beta/typescript/package.json
+++ b/sdk/appconfiguration/arm-appconfiguration/samples/v1-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-appconfiguration-samples-ts-beta",
+  "name": "@azure-samples/arm-appconfiguration-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/appconfiguration/arm-appconfiguration/samples/v1-beta/typescript/package.json
+++ b/sdk/appconfiguration/arm-appconfiguration/samples/v1-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-appconfiguration-samples-ts-beta",
+  "name": "@azure-samples/arm-appconfiguration-samples-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/appplatform/arm-appplatform/samples/v1-beta/javascript/package.json
+++ b/sdk/appplatform/arm-appplatform/samples/v1-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-appplatform-samples-js-beta",
+  "name": "@azure-samples/arm-appplatform-samples-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/appplatform/arm-appplatform/samples/v1-beta/javascript/package.json
+++ b/sdk/appplatform/arm-appplatform/samples/v1-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-appplatform-samples-js-beta",
+  "name": "@azure-samples/arm-appplatform-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/appplatform/arm-appplatform/samples/v1-beta/typescript/package.json
+++ b/sdk/appplatform/arm-appplatform/samples/v1-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-appplatform-samples-ts-beta",
+  "name": "@azure-samples/arm-appplatform-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/appplatform/arm-appplatform/samples/v1-beta/typescript/package.json
+++ b/sdk/appplatform/arm-appplatform/samples/v1-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-appplatform-samples-ts-beta",
+  "name": "@azure-samples/arm-appplatform-samples-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/appplatform/arm-appplatform/samples/v2-beta/javascript/package.json
+++ b/sdk/appplatform/arm-appplatform/samples/v2-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-appplatform-samples-js-beta",
+  "name": "@azure-samples/arm-appplatform-samples-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/appplatform/arm-appplatform/samples/v2-beta/javascript/package.json
+++ b/sdk/appplatform/arm-appplatform/samples/v2-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-appplatform-samples-js-beta",
+  "name": "@azure-samples/arm-appplatform-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/appplatform/arm-appplatform/samples/v2-beta/typescript/package.json
+++ b/sdk/appplatform/arm-appplatform/samples/v2-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-appplatform-samples-ts-beta",
+  "name": "@azure-samples/arm-appplatform-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/appplatform/arm-appplatform/samples/v2-beta/typescript/package.json
+++ b/sdk/appplatform/arm-appplatform/samples/v2-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-appplatform-samples-ts-beta",
+  "name": "@azure-samples/arm-appplatform-samples-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/azurestackhci/arm-azurestackhci/samples/v1-beta/javascript/package.json
+++ b/sdk/azurestackhci/arm-azurestackhci/samples/v1-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-azurestackhci-samples-js-beta",
+  "name": "@azure-samples/arm-azurestackhci-samples-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/azurestackhci/arm-azurestackhci/samples/v1-beta/javascript/package.json
+++ b/sdk/azurestackhci/arm-azurestackhci/samples/v1-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-azurestackhci-samples-js-beta",
+  "name": "@azure-samples/arm-azurestackhci-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/azurestackhci/arm-azurestackhci/samples/v1-beta/typescript/package.json
+++ b/sdk/azurestackhci/arm-azurestackhci/samples/v1-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-azurestackhci-samples-ts-beta",
+  "name": "@azure-samples/arm-azurestackhci-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/azurestackhci/arm-azurestackhci/samples/v1-beta/typescript/package.json
+++ b/sdk/azurestackhci/arm-azurestackhci/samples/v1-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-azurestackhci-samples-ts-beta",
+  "name": "@azure-samples/arm-azurestackhci-samples-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/batch/arm-batch/samples/v7/javascript/package.json
+++ b/sdk/batch/arm-batch/samples/v7/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-batch-samples-js",
+  "name": "@azure-samples/arm-batch-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/batch/arm-batch/samples/v7/javascript/package.json
+++ b/sdk/batch/arm-batch/samples/v7/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-batch-samples-js",
+  "name": "@azure-samples/arm-batch-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/batch/arm-batch/samples/v7/typescript/package.json
+++ b/sdk/batch/arm-batch/samples/v7/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-batch-samples-ts",
+  "name": "@azure-samples/arm-batch-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/batch/arm-batch/samples/v7/typescript/package.json
+++ b/sdk/batch/arm-batch/samples/v7/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-batch-samples-ts",
+  "name": "@azure-samples/arm-batch-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/cdn/arm-cdn/samples/v7/javascript/package.json
+++ b/sdk/cdn/arm-cdn/samples/v7/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-cdn-samples-js",
+  "name": "@azure-samples/arm-cdn-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/cdn/arm-cdn/samples/v7/javascript/package.json
+++ b/sdk/cdn/arm-cdn/samples/v7/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-cdn-samples-js",
+  "name": "@azure-samples/arm-cdn-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/cdn/arm-cdn/samples/v7/typescript/package.json
+++ b/sdk/cdn/arm-cdn/samples/v7/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-cdn-samples-ts",
+  "name": "@azure-samples/arm-cdn-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/cdn/arm-cdn/samples/v7/typescript/package.json
+++ b/sdk/cdn/arm-cdn/samples/v7/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-cdn-samples-ts",
+  "name": "@azure-samples/arm-cdn-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/commerce/arm-commerce/samples/v4-beta/javascript/package.json
+++ b/sdk/commerce/arm-commerce/samples/v4-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-commerce-samples-js-beta",
+  "name": "@azure-samples/arm-commerce-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/commerce/arm-commerce/samples/v4-beta/javascript/package.json
+++ b/sdk/commerce/arm-commerce/samples/v4-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-commerce-samples-js-beta",
+  "name": "@azure-samples/arm-commerce-samples-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/commerce/arm-commerce/samples/v4-beta/typescript/package.json
+++ b/sdk/commerce/arm-commerce/samples/v4-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-commerce-samples-ts-beta",
+  "name": "@azure-samples/arm-commerce-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/commerce/arm-commerce/samples/v4-beta/typescript/package.json
+++ b/sdk/commerce/arm-commerce/samples/v4-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-commerce-samples-ts-beta",
+  "name": "@azure-samples/arm-commerce-samples-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/communication/communication-chat/samples/v1/javascript/package.json
+++ b/sdk/communication/communication-chat/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/communication-chat-samples-js",
+  "name": "@azure-samples/communication-chat-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Communication Services - Chat client library samples for JavaScript",

--- a/sdk/communication/communication-chat/samples/v1/javascript/package.json
+++ b/sdk/communication/communication-chat/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-communication-chat-samples-js",
+  "name": "@azure-samples/communication-chat-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Communication Services - Chat client library samples for JavaScript",

--- a/sdk/communication/communication-chat/samples/v1/typescript/package.json
+++ b/sdk/communication/communication-chat/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-communication-chat-samples-ts",
+  "name": "@azure-samples/communication-chat-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Communication Services - Chat client library samples for TypeScript",

--- a/sdk/communication/communication-chat/samples/v1/typescript/package.json
+++ b/sdk/communication/communication-chat/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/communication-chat-samples-ts",
+  "name": "@azure-samples/communication-chat-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Communication Services - Chat client library samples for TypeScript",

--- a/sdk/communication/communication-identity/samples/v1/javascript/package.json
+++ b/sdk/communication/communication-identity/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-communication-identity-samples-js",
+  "name": "@azure-samples/communication-identity-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Communication Services - Identity client library samples for JavaScript",

--- a/sdk/communication/communication-identity/samples/v1/javascript/package.json
+++ b/sdk/communication/communication-identity/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/communication-identity-samples-js",
+  "name": "@azure-samples/communication-identity-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Communication Services - Identity client library samples for JavaScript",

--- a/sdk/communication/communication-identity/samples/v1/typescript/package.json
+++ b/sdk/communication/communication-identity/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-communication-identity-samples-ts",
+  "name": "@azure-samples/communication-identity-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Communication Services - Identity client library samples for TypeScript",

--- a/sdk/communication/communication-identity/samples/v1/typescript/package.json
+++ b/sdk/communication/communication-identity/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/communication-identity-samples-ts",
+  "name": "@azure-samples/communication-identity-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Communication Services - Identity client library samples for TypeScript",

--- a/sdk/communication/communication-network-traversal/samples/v1/javascript/package.json
+++ b/sdk/communication/communication-network-traversal/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/communication-network-traversal-samples-js",
+  "name": "@azure-samples/communication-network-traversal-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Communication Services - Network Traversal client library samples for JavaScript",

--- a/sdk/communication/communication-network-traversal/samples/v1/javascript/package.json
+++ b/sdk/communication/communication-network-traversal/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-communication-network-traversal-samples-js",
+  "name": "@azure-samples/communication-network-traversal-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Communication Services - Network Traversal client library samples for JavaScript",

--- a/sdk/communication/communication-network-traversal/samples/v1/typescript/package.json
+++ b/sdk/communication/communication-network-traversal/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-communication-network-traversal-samples-ts",
+  "name": "@azure-samples/communication-network-traversal-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Communication Services - Network Traversal client library samples for TypeScript",

--- a/sdk/communication/communication-network-traversal/samples/v1/typescript/package.json
+++ b/sdk/communication/communication-network-traversal/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/communication-network-traversal-samples-ts",
+  "name": "@azure-samples/communication-network-traversal-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Communication Services - Network Traversal client library samples for TypeScript",

--- a/sdk/communication/communication-phone-numbers/samples/v1/javascript/package.json
+++ b/sdk/communication/communication-phone-numbers/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-communication-phone-numbers-samples-js",
+  "name": "@azure-samples/communication-phone-numbers-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Communication Services - Phone Numbers client library samples for JavaScript",

--- a/sdk/communication/communication-phone-numbers/samples/v1/javascript/package.json
+++ b/sdk/communication/communication-phone-numbers/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/communication-phone-numbers-samples-js",
+  "name": "@azure-samples/communication-phone-numbers-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Communication Services - Phone Numbers client library samples for JavaScript",

--- a/sdk/communication/communication-phone-numbers/samples/v1/typescript/package.json
+++ b/sdk/communication/communication-phone-numbers/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/communication-phone-numbers-samples-ts",
+  "name": "@azure-samples/communication-phone-numbers-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Communication Services - Phone Numbers client library samples for TypeScript",

--- a/sdk/communication/communication-phone-numbers/samples/v1/typescript/package.json
+++ b/sdk/communication/communication-phone-numbers/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-communication-phone-numbers-samples-ts",
+  "name": "@azure-samples/communication-phone-numbers-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Communication Services - Phone Numbers client library samples for TypeScript",

--- a/sdk/communication/communication-short-codes/samples/v1/javascript/package.json
+++ b/sdk/communication/communication-short-codes/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/communication-short-codes-samples-js",
+  "name": "@azure-samples/communication-short-codes-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Communication Services - Short Codes client library samples for JavaScript",

--- a/sdk/communication/communication-short-codes/samples/v1/javascript/package.json
+++ b/sdk/communication/communication-short-codes/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-communication-short-codes-samples-js",
+  "name": "@azure-samples/communication-short-codes-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Communication Services - Short Codes client library samples for JavaScript",

--- a/sdk/communication/communication-short-codes/samples/v1/typescript/package.json
+++ b/sdk/communication/communication-short-codes/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-communication-short-codes-samples-ts",
+  "name": "@azure-samples/communication-short-codes-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Communication Services - Short Codes client library samples for TypeScript",

--- a/sdk/communication/communication-short-codes/samples/v1/typescript/package.json
+++ b/sdk/communication/communication-short-codes/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/communication-short-codes-samples-ts",
+  "name": "@azure-samples/communication-short-codes-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Communication Services - Short Codes client library samples for TypeScript",

--- a/sdk/communication/communication-sms/samples/v1/javascript/package.json
+++ b/sdk/communication/communication-sms/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/communication-sms-samples-js",
+  "name": "@azure-samples/communication-sms-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Communication Services - SMS client library samples for JavaScript",

--- a/sdk/communication/communication-sms/samples/v1/javascript/package.json
+++ b/sdk/communication/communication-sms/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-communication-sms-samples-js",
+  "name": "@azure-samples/communication-sms-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Communication Services - SMS client library samples for JavaScript",

--- a/sdk/communication/communication-sms/samples/v1/typescript/package.json
+++ b/sdk/communication/communication-sms/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/communication-sms-samples-ts",
+  "name": "@azure-samples/communication-sms-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Communication Services - SMS client library samples for TypeScript",

--- a/sdk/communication/communication-sms/samples/v1/typescript/package.json
+++ b/sdk/communication/communication-sms/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-communication-sms-samples-ts",
+  "name": "@azure-samples/communication-sms-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Communication Services - SMS client library samples for TypeScript",

--- a/sdk/compute/arm-compute/samples/v17/javascript/package.json
+++ b/sdk/compute/arm-compute/samples/v17/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-compute-samples-js",
+  "name": "@azure-samples/arm-compute-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/compute/arm-compute/samples/v17/javascript/package.json
+++ b/sdk/compute/arm-compute/samples/v17/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-compute-samples-js",
+  "name": "@azure-samples/arm-compute-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/compute/arm-compute/samples/v17/typescript/package.json
+++ b/sdk/compute/arm-compute/samples/v17/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-compute-samples-ts",
+  "name": "@azure-samples/arm-compute-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/compute/arm-compute/samples/v17/typescript/package.json
+++ b/sdk/compute/arm-compute/samples/v17/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-compute-samples-ts",
+  "name": "@azure-samples/arm-compute-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/confidentialledger/confidential-ledger-rest/samples/v1/javascript/package.json
+++ b/sdk/confidentialledger/confidential-ledger-rest/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/confidential-ledger-samples-js",
+  "name": "@azure-samples/confidential-ledger-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Confidential Ledger rest client library samples for JavaScript",

--- a/sdk/confidentialledger/confidential-ledger-rest/samples/v1/javascript/package.json
+++ b/sdk/confidentialledger/confidential-ledger-rest/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-confidential-ledger-samples-js",
+  "name": "@azure-samples/confidential-ledger-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Confidential Ledger rest client library samples for JavaScript",

--- a/sdk/confidentialledger/confidential-ledger-rest/samples/v1/typescript/package.json
+++ b/sdk/confidentialledger/confidential-ledger-rest/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/confidential-ledger-samples-ts",
+  "name": "@azure-samples/confidential-ledger-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Confidential Ledger rest client library samples for TypeScript",

--- a/sdk/confidentialledger/confidential-ledger-rest/samples/v1/typescript/package.json
+++ b/sdk/confidentialledger/confidential-ledger-rest/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-confidential-ledger-samples-ts",
+  "name": "@azure-samples/confidential-ledger-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Confidential Ledger rest client library samples for TypeScript",

--- a/sdk/containerregistry/arm-containerregistry/samples/v1-beta/javascript/package.json
+++ b/sdk/containerregistry/arm-containerregistry/samples/v1-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-containerregistry-samples-js-beta",
+  "name": "@azure-samples/arm-containerregistry-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/containerregistry/arm-containerregistry/samples/v1-beta/javascript/package.json
+++ b/sdk/containerregistry/arm-containerregistry/samples/v1-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-containerregistry-samples-js-beta",
+  "name": "@azure-samples/arm-containerregistry-samples-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/containerregistry/arm-containerregistry/samples/v1-beta/typescript/package.json
+++ b/sdk/containerregistry/arm-containerregistry/samples/v1-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-containerregistry-samples-ts-beta",
+  "name": "@azure-samples/arm-containerregistry-samples-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/containerregistry/arm-containerregistry/samples/v1-beta/typescript/package.json
+++ b/sdk/containerregistry/arm-containerregistry/samples/v1-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-containerregistry-samples-ts-beta",
+  "name": "@azure-samples/arm-containerregistry-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/containerregistry/container-registry/samples/v1/javascript/package.json
+++ b/sdk/containerregistry/container-registry/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-container-registry-samples-js",
+  "name": "@azure-samples/container-registry-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Container Registry client library samples for JavaScript",

--- a/sdk/containerregistry/container-registry/samples/v1/javascript/package.json
+++ b/sdk/containerregistry/container-registry/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/container-registry-samples-js",
+  "name": "@azure-samples/container-registry-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Container Registry client library samples for JavaScript",

--- a/sdk/containerregistry/container-registry/samples/v1/typescript/package.json
+++ b/sdk/containerregistry/container-registry/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/container-registry-samples-ts",
+  "name": "@azure-samples/container-registry-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Container Registry client library samples for TypeScript",

--- a/sdk/containerregistry/container-registry/samples/v1/typescript/package.json
+++ b/sdk/containerregistry/container-registry/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-container-registry-samples-ts",
+  "name": "@azure-samples/container-registry-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Container Registry client library samples for TypeScript",

--- a/sdk/containerservice/arm-containerservice/samples/v15/javascript/package.json
+++ b/sdk/containerservice/arm-containerservice/samples/v15/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-containerservice-samples-js",
+  "name": "@azure-samples/arm-containerservice-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/containerservice/arm-containerservice/samples/v15/javascript/package.json
+++ b/sdk/containerservice/arm-containerservice/samples/v15/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-containerservice-samples-js",
+  "name": "@azure-samples/arm-containerservice-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/containerservice/arm-containerservice/samples/v15/typescript/package.json
+++ b/sdk/containerservice/arm-containerservice/samples/v15/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-containerservice-samples-ts",
+  "name": "@azure-samples/arm-containerservice-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/containerservice/arm-containerservice/samples/v15/typescript/package.json
+++ b/sdk/containerservice/arm-containerservice/samples/v15/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-containerservice-samples-ts",
+  "name": "@azure-samples/arm-containerservice-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/core/core-paging/samples/v1/javascript/package.json
+++ b/sdk/core/core-paging/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-core-paging-samples-js",
+  "name": "@azure-samples/core-paging-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure SDK Core client library samples for JavaScript",

--- a/sdk/core/core-paging/samples/v1/javascript/package.json
+++ b/sdk/core/core-paging/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/core-paging-samples-js",
+  "name": "@azure-samples/core-paging-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure SDK Core client library samples for JavaScript",

--- a/sdk/core/core-paging/samples/v1/typescript/package.json
+++ b/sdk/core/core-paging/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/core-paging-samples-ts",
+  "name": "@azure-samples/core-paging-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure SDK Core client library samples for TypeScript",

--- a/sdk/core/core-paging/samples/v1/typescript/package.json
+++ b/sdk/core/core-paging/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-core-paging-samples-ts",
+  "name": "@azure-samples/core-paging-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure SDK Core client library samples for TypeScript",

--- a/sdk/core/core-rest-pipeline/samples/v1/javascript/package.json
+++ b/sdk/core/core-rest-pipeline/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-core-rest-pipeline-samples-js",
+  "name": "@azure-samples/core-rest-pipeline-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure SDK Core client library samples for JavaScript",

--- a/sdk/core/core-rest-pipeline/samples/v1/javascript/package.json
+++ b/sdk/core/core-rest-pipeline/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/core-rest-pipeline-samples-js",
+  "name": "@azure-samples/core-rest-pipeline-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure SDK Core client library samples for JavaScript",

--- a/sdk/core/core-rest-pipeline/samples/v1/typescript/package.json
+++ b/sdk/core/core-rest-pipeline/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/core-rest-pipeline-samples-ts",
+  "name": "@azure-samples/core-rest-pipeline-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure SDK Core client library samples for TypeScript",

--- a/sdk/core/core-rest-pipeline/samples/v1/typescript/package.json
+++ b/sdk/core/core-rest-pipeline/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-core-rest-pipeline-samples-ts",
+  "name": "@azure-samples/core-rest-pipeline-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure SDK Core client library samples for TypeScript",

--- a/sdk/core/core-tracing/samples/v1/javascript/package.json
+++ b/sdk/core/core-tracing/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-core-tracing-samples-js",
+  "name": "@azure-samples/core-tracing-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure SDK Core client library samples for JavaScript",

--- a/sdk/core/core-tracing/samples/v1/javascript/package.json
+++ b/sdk/core/core-tracing/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/core-tracing-samples-js",
+  "name": "@azure-samples/core-tracing-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure SDK Core client library samples for JavaScript",

--- a/sdk/core/core-tracing/samples/v1/typescript/package.json
+++ b/sdk/core/core-tracing/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/core-tracing-samples-ts",
+  "name": "@azure-samples/core-tracing-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure SDK Core client library samples for TypeScript",

--- a/sdk/core/core-tracing/samples/v1/typescript/package.json
+++ b/sdk/core/core-tracing/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-core-tracing-samples-ts",
+  "name": "@azure-samples/core-tracing-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure SDK Core client library samples for TypeScript",

--- a/sdk/cosmosdb/cosmos/samples/v3/javascript/package.json
+++ b/sdk/cosmosdb/cosmos/samples/v3/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/cosmos-samples-js",
+  "name": "@azure-samples/cosmos-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Cosmos DB client library samples for JavaScript",

--- a/sdk/cosmosdb/cosmos/samples/v3/javascript/package.json
+++ b/sdk/cosmosdb/cosmos/samples/v3/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-cosmos-samples-js",
+  "name": "@azure-samples/cosmos-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Cosmos DB client library samples for JavaScript",

--- a/sdk/cosmosdb/cosmos/samples/v3/typescript/package.json
+++ b/sdk/cosmosdb/cosmos/samples/v3/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/cosmos-samples-ts",
+  "name": "@azure-samples/cosmos-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Cosmos DB client library samples for TypeScript",

--- a/sdk/cosmosdb/cosmos/samples/v3/typescript/package.json
+++ b/sdk/cosmosdb/cosmos/samples/v3/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-cosmos-samples-ts",
+  "name": "@azure-samples/cosmos-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Cosmos DB client library samples for TypeScript",

--- a/sdk/datafactory/arm-datafactory/samples/v10/javascript/package.json
+++ b/sdk/datafactory/arm-datafactory/samples/v10/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-datafactory-samples-js",
+  "name": "@azure-samples/arm-datafactory-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/datafactory/arm-datafactory/samples/v10/javascript/package.json
+++ b/sdk/datafactory/arm-datafactory/samples/v10/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-datafactory-samples-js",
+  "name": "@azure-samples/arm-datafactory-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/datafactory/arm-datafactory/samples/v10/typescript/package.json
+++ b/sdk/datafactory/arm-datafactory/samples/v10/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-datafactory-samples-ts",
+  "name": "@azure-samples/arm-datafactory-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/datafactory/arm-datafactory/samples/v10/typescript/package.json
+++ b/sdk/datafactory/arm-datafactory/samples/v10/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-datafactory-samples-ts",
+  "name": "@azure-samples/arm-datafactory-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/datamigration/arm-datamigration/samples/v3-beta/javascript/package.json
+++ b/sdk/datamigration/arm-datamigration/samples/v3-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-datamigration-samples-js-beta",
+  "name": "@azure-samples/arm-datamigration-samples-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/datamigration/arm-datamigration/samples/v3-beta/javascript/package.json
+++ b/sdk/datamigration/arm-datamigration/samples/v3-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-datamigration-samples-js-beta",
+  "name": "@azure-samples/arm-datamigration-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/datamigration/arm-datamigration/samples/v3-beta/typescript/package.json
+++ b/sdk/datamigration/arm-datamigration/samples/v3-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-datamigration-samples-ts-beta",
+  "name": "@azure-samples/arm-datamigration-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/datamigration/arm-datamigration/samples/v3-beta/typescript/package.json
+++ b/sdk/datamigration/arm-datamigration/samples/v3-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-datamigration-samples-ts-beta",
+  "name": "@azure-samples/arm-datamigration-samples-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/samples/v4/javascript/package.json
+++ b/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/samples/v4/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-deviceprovisioningservices-samples-js",
+  "name": "@azure-samples/arm-deviceprovisioningservices-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/samples/v4/javascript/package.json
+++ b/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/samples/v4/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-deviceprovisioningservices-samples-js",
+  "name": "@azure-samples/arm-deviceprovisioningservices-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/samples/v4/typescript/package.json
+++ b/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/samples/v4/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-deviceprovisioningservices-samples-ts",
+  "name": "@azure-samples/arm-deviceprovisioningservices-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/samples/v4/typescript/package.json
+++ b/sdk/deviceprovisioningservices/arm-deviceprovisioningservices/samples/v4/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-deviceprovisioningservices-samples-ts",
+  "name": "@azure-samples/arm-deviceprovisioningservices-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/deviceupdate/iot-device-update-rest/samples/v1/javascript/package.json
+++ b/sdk/deviceupdate/iot-device-update-rest/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-iot-device-update-samples-js",
+  "name": "@azure-samples/iot-device-update-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure IoT Hub Device Update rest client library samples for JavaScript",

--- a/sdk/deviceupdate/iot-device-update-rest/samples/v1/javascript/package.json
+++ b/sdk/deviceupdate/iot-device-update-rest/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/iot-device-update-samples-js",
+  "name": "@azure-samples/iot-device-update-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure IoT Hub Device Update rest client library samples for JavaScript",

--- a/sdk/deviceupdate/iot-device-update-rest/samples/v1/typescript/package.json
+++ b/sdk/deviceupdate/iot-device-update-rest/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-iot-device-update-samples-ts",
+  "name": "@azure-samples/iot-device-update-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure IoT Hub Device Update rest client library samples for TypeScript",

--- a/sdk/deviceupdate/iot-device-update-rest/samples/v1/typescript/package.json
+++ b/sdk/deviceupdate/iot-device-update-rest/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/iot-device-update-samples-ts",
+  "name": "@azure-samples/iot-device-update-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure IoT Hub Device Update rest client library samples for TypeScript",

--- a/sdk/digitaltwins/arm-digitaltwins/samples/v1-beta/javascript/package.json
+++ b/sdk/digitaltwins/arm-digitaltwins/samples/v1-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-digitaltwins-samples-js-beta",
+  "name": "@azure-samples/arm-digitaltwins-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/digitaltwins/arm-digitaltwins/samples/v1-beta/javascript/package.json
+++ b/sdk/digitaltwins/arm-digitaltwins/samples/v1-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-digitaltwins-samples-js-beta",
+  "name": "@azure-samples/arm-digitaltwins-samples-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/digitaltwins/arm-digitaltwins/samples/v1-beta/typescript/package.json
+++ b/sdk/digitaltwins/arm-digitaltwins/samples/v1-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-digitaltwins-samples-ts-beta",
+  "name": "@azure-samples/arm-digitaltwins-samples-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/digitaltwins/arm-digitaltwins/samples/v1-beta/typescript/package.json
+++ b/sdk/digitaltwins/arm-digitaltwins/samples/v1-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-digitaltwins-samples-ts-beta",
+  "name": "@azure-samples/arm-digitaltwins-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/digitaltwins/digital-twins-core/samples/v1/javascript/package.json
+++ b/sdk/digitaltwins/digital-twins-core/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/digital-twins-core-samples-js",
+  "name": "@azure-samples/digital-twins-core-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Digital Twins client library samples for JavaScript",

--- a/sdk/digitaltwins/digital-twins-core/samples/v1/javascript/package.json
+++ b/sdk/digitaltwins/digital-twins-core/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-digital-twins-core-samples-js",
+  "name": "@azure-samples/digital-twins-core-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Digital Twins client library samples for JavaScript",

--- a/sdk/digitaltwins/digital-twins-core/samples/v1/typescript/package.json
+++ b/sdk/digitaltwins/digital-twins-core/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-digital-twins-core-samples-ts",
+  "name": "@azure-samples/digital-twins-core-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Digital Twins client library samples for TypeScript",

--- a/sdk/digitaltwins/digital-twins-core/samples/v1/typescript/package.json
+++ b/sdk/digitaltwins/digital-twins-core/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/digital-twins-core-samples-ts",
+  "name": "@azure-samples/digital-twins-core-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Digital Twins client library samples for TypeScript",

--- a/sdk/digitaltwins/dtdl-parser/samples/v1-beta/javascript/package.json
+++ b/sdk/digitaltwins/dtdl-parser/samples/v1-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/dtdl-parser-samples-js-beta",
+  "name": "@azure-samples/dtdl-parser-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Digital Twins Model Parser client library samples for JavaScript (Beta)",

--- a/sdk/digitaltwins/dtdl-parser/samples/v1-beta/javascript/package.json
+++ b/sdk/digitaltwins/dtdl-parser/samples/v1-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-dtdl-parser-samples-js-beta",
+  "name": "@azure-samples/dtdl-parser-samples-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Digital Twins Model Parser client library samples for JavaScript (Beta)",

--- a/sdk/digitaltwins/dtdl-parser/samples/v1-beta/typescript/package.json
+++ b/sdk/digitaltwins/dtdl-parser/samples/v1-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-dtdl-parser-samples-ts-beta",
+  "name": "@azure-samples/dtdl-parser-samples-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Digital Twins Model Parser client library samples for TypeScript (Beta)",

--- a/sdk/digitaltwins/dtdl-parser/samples/v1-beta/typescript/package.json
+++ b/sdk/digitaltwins/dtdl-parser/samples/v1-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/dtdl-parser-samples-ts-beta",
+  "name": "@azure-samples/dtdl-parser-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Digital Twins Model Parser client library samples for TypeScript (Beta)",

--- a/sdk/dnsresolver/arm-dnsresolver/samples/v1-beta/javascript/package.json
+++ b/sdk/dnsresolver/arm-dnsresolver/samples/v1-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-dnsresolver-samples-js-beta",
+  "name": "@azure-samples/arm-dnsresolver-samples-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/dnsresolver/arm-dnsresolver/samples/v1-beta/javascript/package.json
+++ b/sdk/dnsresolver/arm-dnsresolver/samples/v1-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-dnsresolver-samples-js-beta",
+  "name": "@azure-samples/arm-dnsresolver-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/dnsresolver/arm-dnsresolver/samples/v1-beta/typescript/package.json
+++ b/sdk/dnsresolver/arm-dnsresolver/samples/v1-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-dnsresolver-samples-ts-beta",
+  "name": "@azure-samples/arm-dnsresolver-samples-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/dnsresolver/arm-dnsresolver/samples/v1-beta/typescript/package.json
+++ b/sdk/dnsresolver/arm-dnsresolver/samples/v1-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-dnsresolver-samples-ts-beta",
+  "name": "@azure-samples/arm-dnsresolver-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/documenttranslator/ai-document-translator-rest/samples/v1/javascript/package.json
+++ b/sdk/documenttranslator/ai-document-translator-rest/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/ai-document-translator-samples-js",
+  "name": "@azure-samples/ai-document-translator-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Document Translator rest client library samples for JavaScript",

--- a/sdk/documenttranslator/ai-document-translator-rest/samples/v1/javascript/package.json
+++ b/sdk/documenttranslator/ai-document-translator-rest/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-ai-document-translator-samples-js",
+  "name": "@azure-samples/ai-document-translator-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Document Translator rest client library samples for JavaScript",

--- a/sdk/documenttranslator/ai-document-translator-rest/samples/v1/typescript/package.json
+++ b/sdk/documenttranslator/ai-document-translator-rest/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-ai-document-translator-samples-ts",
+  "name": "@azure-samples/ai-document-translator-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Document Translator rest client library samples for TypeScript",

--- a/sdk/documenttranslator/ai-document-translator-rest/samples/v1/typescript/package.json
+++ b/sdk/documenttranslator/ai-document-translator-rest/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/ai-document-translator-samples-ts",
+  "name": "@azure-samples/ai-document-translator-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Document Translator rest client library samples for TypeScript",

--- a/sdk/eventgrid/eventgrid/samples/v4/javascript/package.json
+++ b/sdk/eventgrid/eventgrid/samples/v4/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/eventgrid-samples-js",
+  "name": "@azure-samples/eventgrid-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Event Grid client library samples for JavaScript",

--- a/sdk/eventgrid/eventgrid/samples/v4/javascript/package.json
+++ b/sdk/eventgrid/eventgrid/samples/v4/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-eventgrid-samples-js",
+  "name": "@azure-samples/eventgrid-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Event Grid client library samples for JavaScript",

--- a/sdk/eventgrid/eventgrid/samples/v4/typescript/package.json
+++ b/sdk/eventgrid/eventgrid/samples/v4/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-eventgrid-samples-ts",
+  "name": "@azure-samples/eventgrid-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Event Grid client library samples for TypeScript",

--- a/sdk/eventgrid/eventgrid/samples/v4/typescript/package.json
+++ b/sdk/eventgrid/eventgrid/samples/v4/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/eventgrid-samples-ts",
+  "name": "@azure-samples/eventgrid-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Event Grid client library samples for TypeScript",

--- a/sdk/eventhub/event-hubs/samples-browser/package.json
+++ b/sdk/eventhub/event-hubs/samples-browser/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-event-hubs-samples-browser",
+  "name": "@azure-samples/event-hubs-samples-browser",
   "private": true,
   "version": "0.1.0",
   "description": "Azure Event Hubs client library samples for JavaScript",

--- a/sdk/eventhub/event-hubs/samples-express/package.json
+++ b/sdk/eventhub/event-hubs/samples-express/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-event-hubs-samples-express",
+  "name": "@azure-samples/event-hubs-samples-express",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Event Hubs client library samples with Express",

--- a/sdk/eventhub/event-hubs/samples/v5/browser/package.json
+++ b/sdk/eventhub/event-hubs/samples/v5/browser/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-event-hubs-samples-browser",
+  "name": "@azure-samples/event-hubs-samples-browser",
   "private": true,
   "version": "0.1.0",
   "description": "Azure Event Hubs client library samples for JavaScript",

--- a/sdk/eventhub/event-hubs/samples/v5/express/package.json
+++ b/sdk/eventhub/event-hubs/samples/v5/express/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-event-hubs-samples-express",
+  "name": "@azure-samples/event-hubs-samples-express",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Event Hubs client library samples with Express",

--- a/sdk/eventhub/event-hubs/samples/v5/javascript/package.json
+++ b/sdk/eventhub/event-hubs/samples/v5/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-event-hubs-samples-js",
+  "name": "@azure-samples/event-hubs-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Event Hubs client library samples for JavaScript",

--- a/sdk/eventhub/event-hubs/samples/v5/javascript/package.json
+++ b/sdk/eventhub/event-hubs/samples/v5/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/event-hubs-samples-js",
+  "name": "@azure-samples/event-hubs-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Event Hubs client library samples for JavaScript",

--- a/sdk/eventhub/event-hubs/samples/v5/typescript/package.json
+++ b/sdk/eventhub/event-hubs/samples/v5/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-event-hubs-samples-ts",
+  "name": "@azure-samples/event-hubs-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Event Hubs client library samples for TypeScript",

--- a/sdk/eventhub/event-hubs/samples/v5/typescript/package.json
+++ b/sdk/eventhub/event-hubs/samples/v5/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/event-hubs-samples-ts",
+  "name": "@azure-samples/event-hubs-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Event Hubs client library samples for TypeScript",

--- a/sdk/eventhub/event-processor-host/samples/javascript/package.json
+++ b/sdk/eventhub/event-processor-host/samples/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-event-processor-host-samples-ts",
+  "name": "@azure-samples/event-processor-host-samples-ts",
   "private": true,
   "version": "0.1.0",
   "description": "Azure Event Process Host (Event Hubs) library samples for JavaScript",

--- a/sdk/eventhub/event-processor-host/samples/javascript/package.json
+++ b/sdk/eventhub/event-processor-host/samples/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/event-processor-host-samples-ts",
+  "name": "@azure-samples/event-processor-host-ts",
   "private": true,
   "version": "0.1.0",
   "description": "Azure Event Process Host (Event Hubs) library samples for JavaScript",

--- a/sdk/eventhub/event-processor-host/samples/typescript/package.json
+++ b/sdk/eventhub/event-processor-host/samples/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-event-processor-host-samples-ts",
+  "name": "@azure-samples/event-processor-host-samples-ts",
   "private": true,
   "version": "0.1.0",
   "description": "Azure Event Process Host (Event Hubs) library samples for TypeScript",

--- a/sdk/eventhub/event-processor-host/samples/typescript/package.json
+++ b/sdk/eventhub/event-processor-host/samples/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/event-processor-host-samples-ts",
+  "name": "@azure-samples/event-processor-host-ts",
   "private": true,
   "version": "0.1.0",
   "description": "Azure Event Process Host (Event Hubs) library samples for TypeScript",

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/samples/v1/javascript/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/eventhubs-checkpointstore-blob-samples-js",
+  "name": "@azure-samples/eventhubs-checkpointstore-blob-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Event Hubs - Checkpoint Store client library samples for JavaScript",

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/samples/v1/javascript/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-eventhubs-checkpointstore-blob-samples-js",
+  "name": "@azure-samples/eventhubs-checkpointstore-blob-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Event Hubs - Checkpoint Store client library samples for JavaScript",

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/samples/v1/typescript/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/eventhubs-checkpointstore-blob-samples-ts",
+  "name": "@azure-samples/eventhubs-checkpointstore-blob-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Event Hubs - Checkpoint Store client library samples for TypeScript",

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/samples/v1/typescript/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-eventhubs-checkpointstore-blob-samples-ts",
+  "name": "@azure-samples/eventhubs-checkpointstore-blob-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Event Hubs - Checkpoint Store client library samples for TypeScript",

--- a/sdk/eventhub/mock-hub/samples/javascript/package.json
+++ b/sdk/eventhub/mock-hub/samples/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-mock-hub-samples-js",
+  "name": "@azure-samples/mock-hub-samples-js",
   "private": true,
   "version": "0.1.0",
   "description": "Azure Mock Hub client library samples for JavaScript",

--- a/sdk/eventhub/mock-hub/samples/javascript/package.json
+++ b/sdk/eventhub/mock-hub/samples/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/mock-hub-samples-js",
+  "name": "@azure-samples/mock-hub-js",
   "private": true,
   "version": "0.1.0",
   "description": "Azure Mock Hub client library samples for JavaScript",

--- a/sdk/eventhub/mock-hub/samples/typescript/package.json
+++ b/sdk/eventhub/mock-hub/samples/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/mock-hub-samples-ts",
+  "name": "@azure-samples/mock-hub-ts",
   "private": true,
   "version": "0.1.0",
   "description": "Azure Mock Hub client library samples for TypeScript",

--- a/sdk/eventhub/mock-hub/samples/typescript/package.json
+++ b/sdk/eventhub/mock-hub/samples/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-mock-hub-samples-ts",
+  "name": "@azure-samples/mock-hub-samples-ts",
   "private": true,
   "version": "0.1.0",
   "description": "Azure Mock Hub client library samples for TypeScript",

--- a/sdk/formrecognizer/ai-form-recognizer/samples/v3/javascript/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/v3/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/ai-form-recognizer-samples-js",
+  "name": "@azure-samples/ai-form-recognizer-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Form Recognizer client library samples for JavaScript",

--- a/sdk/formrecognizer/ai-form-recognizer/samples/v3/javascript/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/v3/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-ai-form-recognizer-samples-js",
+  "name": "@azure-samples/ai-form-recognizer-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Form Recognizer client library samples for JavaScript",

--- a/sdk/formrecognizer/ai-form-recognizer/samples/v3/typescript/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/v3/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-ai-form-recognizer-samples-ts",
+  "name": "@azure-samples/ai-form-recognizer-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Form Recognizer client library samples for TypeScript",

--- a/sdk/formrecognizer/ai-form-recognizer/samples/v3/typescript/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/v3/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/ai-form-recognizer-samples-ts",
+  "name": "@azure-samples/ai-form-recognizer-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Form Recognizer client library samples for TypeScript",

--- a/sdk/formrecognizer/ai-form-recognizer/samples/v4-beta/javascript/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/v4-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-ai-form-recognizer-samples-js-beta",
+  "name": "@azure-samples/ai-form-recognizer-samples-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Form Recognizer client library samples for JavaScript (Beta)",

--- a/sdk/formrecognizer/ai-form-recognizer/samples/v4-beta/javascript/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/v4-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/ai-form-recognizer-samples-js-beta",
+  "name": "@azure-samples/ai-form-recognizer-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Form Recognizer client library samples for JavaScript (Beta)",

--- a/sdk/formrecognizer/ai-form-recognizer/samples/v4-beta/typescript/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/v4-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-ai-form-recognizer-samples-ts-beta",
+  "name": "@azure-samples/ai-form-recognizer-samples-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Form Recognizer client library samples for TypeScript (Beta)",

--- a/sdk/formrecognizer/ai-form-recognizer/samples/v4-beta/typescript/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/v4-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/ai-form-recognizer-samples-ts-beta",
+  "name": "@azure-samples/ai-form-recognizer-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Form Recognizer client library samples for TypeScript (Beta)",

--- a/sdk/healthcareapis/arm-healthcareapis/samples/v2/javascript/package.json
+++ b/sdk/healthcareapis/arm-healthcareapis/samples/v2/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-healthcareapis-samples-js",
+  "name": "@azure-samples/arm-healthcareapis-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/healthcareapis/arm-healthcareapis/samples/v2/javascript/package.json
+++ b/sdk/healthcareapis/arm-healthcareapis/samples/v2/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-healthcareapis-samples-js",
+  "name": "@azure-samples/arm-healthcareapis-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/healthcareapis/arm-healthcareapis/samples/v2/typescript/package.json
+++ b/sdk/healthcareapis/arm-healthcareapis/samples/v2/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-healthcareapis-samples-ts",
+  "name": "@azure-samples/arm-healthcareapis-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/healthcareapis/arm-healthcareapis/samples/v2/typescript/package.json
+++ b/sdk/healthcareapis/arm-healthcareapis/samples/v2/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-healthcareapis-samples-ts",
+  "name": "@azure-samples/arm-healthcareapis-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/hybridcompute/arm-hybridcompute/samples/v3/javascript/package.json
+++ b/sdk/hybridcompute/arm-hybridcompute/samples/v3/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-hybridcompute-samples-js",
+  "name": "@azure-samples/arm-hybridcompute-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/hybridcompute/arm-hybridcompute/samples/v3/javascript/package.json
+++ b/sdk/hybridcompute/arm-hybridcompute/samples/v3/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-hybridcompute-samples-js",
+  "name": "@azure-samples/arm-hybridcompute-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/hybridcompute/arm-hybridcompute/samples/v3/typescript/package.json
+++ b/sdk/hybridcompute/arm-hybridcompute/samples/v3/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-hybridcompute-samples-ts",
+  "name": "@azure-samples/arm-hybridcompute-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/hybridcompute/arm-hybridcompute/samples/v3/typescript/package.json
+++ b/sdk/hybridcompute/arm-hybridcompute/samples/v3/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-hybridcompute-samples-ts",
+  "name": "@azure-samples/arm-hybridcompute-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/hybridkubernetes/arm-hybridkubernetes/samples/v2/javascript/package.json
+++ b/sdk/hybridkubernetes/arm-hybridkubernetes/samples/v2/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-hybridkubernetes-samples-js",
+  "name": "@azure-samples/arm-hybridkubernetes-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/hybridkubernetes/arm-hybridkubernetes/samples/v2/javascript/package.json
+++ b/sdk/hybridkubernetes/arm-hybridkubernetes/samples/v2/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-hybridkubernetes-samples-js",
+  "name": "@azure-samples/arm-hybridkubernetes-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/hybridkubernetes/arm-hybridkubernetes/samples/v2/typescript/package.json
+++ b/sdk/hybridkubernetes/arm-hybridkubernetes/samples/v2/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-hybridkubernetes-samples-ts",
+  "name": "@azure-samples/arm-hybridkubernetes-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/hybridkubernetes/arm-hybridkubernetes/samples/v2/typescript/package.json
+++ b/sdk/hybridkubernetes/arm-hybridkubernetes/samples/v2/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-hybridkubernetes-samples-ts",
+  "name": "@azure-samples/arm-hybridkubernetes-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/identity/identity/samples/v2/javascript/package.json
+++ b/sdk/identity/identity/samples/v2/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-identity-samples-js",
+  "name": "@azure-samples/identity-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Identity client library samples for JavaScript",

--- a/sdk/identity/identity/samples/v2/javascript/package.json
+++ b/sdk/identity/identity/samples/v2/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/identity-samples-js",
+  "name": "@azure-samples/identity-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Identity client library samples for JavaScript",

--- a/sdk/identity/identity/samples/v2/typescript/package.json
+++ b/sdk/identity/identity/samples/v2/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/identity-samples-ts",
+  "name": "@azure-samples/identity-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Identity client library samples for TypeScript",

--- a/sdk/identity/identity/samples/v2/typescript/package.json
+++ b/sdk/identity/identity/samples/v2/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-identity-samples-ts",
+  "name": "@azure-samples/identity-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Identity client library samples for TypeScript",

--- a/sdk/iot/iot-modelsrepository/samples/v1/javascript/package.json
+++ b/sdk/iot/iot-modelsrepository/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/iot-modelsrepository-samples-js",
+  "name": "@azure-samples/iot-modelsrepository-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure IoT Models Repository client library samples for JavaScript",

--- a/sdk/iot/iot-modelsrepository/samples/v1/javascript/package.json
+++ b/sdk/iot/iot-modelsrepository/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-iot-modelsrepository-samples-js",
+  "name": "@azure-samples/iot-modelsrepository-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure IoT Models Repository client library samples for JavaScript",

--- a/sdk/iot/iot-modelsrepository/samples/v1/typescript/package.json
+++ b/sdk/iot/iot-modelsrepository/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-iot-modelsrepository-samples-ts",
+  "name": "@azure-samples/iot-modelsrepository-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure IoT Models Repository client library samples for TypeScript",

--- a/sdk/iot/iot-modelsrepository/samples/v1/typescript/package.json
+++ b/sdk/iot/iot-modelsrepository/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/iot-modelsrepository-samples-ts",
+  "name": "@azure-samples/iot-modelsrepository-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure IoT Models Repository client library samples for TypeScript",

--- a/sdk/iotcentral/arm-iotcentral/samples/v6/javascript/package.json
+++ b/sdk/iotcentral/arm-iotcentral/samples/v6/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-iotcentral-samples-js",
+  "name": "@azure-samples/arm-iotcentral-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/iotcentral/arm-iotcentral/samples/v6/javascript/package.json
+++ b/sdk/iotcentral/arm-iotcentral/samples/v6/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-iotcentral-samples-js",
+  "name": "@azure-samples/arm-iotcentral-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/iotcentral/arm-iotcentral/samples/v6/typescript/package.json
+++ b/sdk/iotcentral/arm-iotcentral/samples/v6/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-iotcentral-samples-ts",
+  "name": "@azure-samples/arm-iotcentral-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/iotcentral/arm-iotcentral/samples/v6/typescript/package.json
+++ b/sdk/iotcentral/arm-iotcentral/samples/v6/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-iotcentral-samples-ts",
+  "name": "@azure-samples/arm-iotcentral-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/iothub/arm-iothub/samples/v6/javascript/package.json
+++ b/sdk/iothub/arm-iothub/samples/v6/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-iothub-samples-js",
+  "name": "@azure-samples/arm-iothub-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/iothub/arm-iothub/samples/v6/javascript/package.json
+++ b/sdk/iothub/arm-iothub/samples/v6/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-iothub-samples-js",
+  "name": "@azure-samples/arm-iothub-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/iothub/arm-iothub/samples/v6/typescript/package.json
+++ b/sdk/iothub/arm-iothub/samples/v6/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-iothub-samples-ts",
+  "name": "@azure-samples/arm-iothub-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/iothub/arm-iothub/samples/v6/typescript/package.json
+++ b/sdk/iothub/arm-iothub/samples/v6/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-iothub-samples-ts",
+  "name": "@azure-samples/arm-iothub-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/keyvault/keyvault-admin/samples/v4/javascript/package.json
+++ b/sdk/keyvault/keyvault-admin/samples/v4/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/keyvault-admin-samples-js",
+  "name": "@azure-samples/keyvault-admin-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Key Vault Administration client library samples for JavaScript",

--- a/sdk/keyvault/keyvault-admin/samples/v4/javascript/package.json
+++ b/sdk/keyvault/keyvault-admin/samples/v4/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-keyvault-admin-samples-js",
+  "name": "@azure-samples/keyvault-admin-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Key Vault Administration client library samples for JavaScript",

--- a/sdk/keyvault/keyvault-admin/samples/v4/typescript/package.json
+++ b/sdk/keyvault/keyvault-admin/samples/v4/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-keyvault-admin-samples-ts",
+  "name": "@azure-samples/keyvault-admin-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Key Vault Administration client library samples for TypeScript",

--- a/sdk/keyvault/keyvault-admin/samples/v4/typescript/package.json
+++ b/sdk/keyvault/keyvault-admin/samples/v4/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/keyvault-admin-samples-ts",
+  "name": "@azure-samples/keyvault-admin-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Key Vault Administration client library samples for TypeScript",

--- a/sdk/keyvault/keyvault-certificates/samples/v4/javascript/package.json
+++ b/sdk/keyvault/keyvault-certificates/samples/v4/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-keyvault-certificates-samples-js",
+  "name": "@azure-samples/keyvault-certificates-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Key Vault Certificates client library samples for JavaScript",

--- a/sdk/keyvault/keyvault-certificates/samples/v4/javascript/package.json
+++ b/sdk/keyvault/keyvault-certificates/samples/v4/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/keyvault-certificates-samples-js",
+  "name": "@azure-samples/keyvault-certificates-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Key Vault Certificates client library samples for JavaScript",

--- a/sdk/keyvault/keyvault-certificates/samples/v4/typescript/package.json
+++ b/sdk/keyvault/keyvault-certificates/samples/v4/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/keyvault-certificates-samples-ts",
+  "name": "@azure-samples/keyvault-certificates-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Key Vault Certificates client library samples for TypeScript",

--- a/sdk/keyvault/keyvault-certificates/samples/v4/typescript/package.json
+++ b/sdk/keyvault/keyvault-certificates/samples/v4/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-keyvault-certificates-samples-ts",
+  "name": "@azure-samples/keyvault-certificates-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Key Vault Certificates client library samples for TypeScript",

--- a/sdk/keyvault/keyvault-keys/samples/v4/javascript/package.json
+++ b/sdk/keyvault/keyvault-keys/samples/v4/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-keyvault-keys-samples-js",
+  "name": "@azure-samples/keyvault-keys-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Key Vault Keys client library samples for JavaScript",

--- a/sdk/keyvault/keyvault-keys/samples/v4/javascript/package.json
+++ b/sdk/keyvault/keyvault-keys/samples/v4/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/keyvault-keys-samples-js",
+  "name": "@azure-samples/keyvault-keys-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Key Vault Keys client library samples for JavaScript",

--- a/sdk/keyvault/keyvault-keys/samples/v4/typescript/package.json
+++ b/sdk/keyvault/keyvault-keys/samples/v4/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/keyvault-keys-samples-ts",
+  "name": "@azure-samples/keyvault-keys-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Key Vault Keys client library samples for TypeScript",

--- a/sdk/keyvault/keyvault-keys/samples/v4/typescript/package.json
+++ b/sdk/keyvault/keyvault-keys/samples/v4/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-keyvault-keys-samples-ts",
+  "name": "@azure-samples/keyvault-keys-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Key Vault Keys client library samples for TypeScript",

--- a/sdk/keyvault/keyvault-secrets/samples/v4/javascript/package.json
+++ b/sdk/keyvault/keyvault-secrets/samples/v4/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/keyvault-secrets-samples-js",
+  "name": "@azure-samples/keyvault-secrets-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Key Vault Keys client library samples for JavaScript",

--- a/sdk/keyvault/keyvault-secrets/samples/v4/javascript/package.json
+++ b/sdk/keyvault/keyvault-secrets/samples/v4/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-keyvault-secrets-samples-js",
+  "name": "@azure-samples/keyvault-secrets-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Key Vault Keys client library samples for JavaScript",

--- a/sdk/keyvault/keyvault-secrets/samples/v4/typescript/package.json
+++ b/sdk/keyvault/keyvault-secrets/samples/v4/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-keyvault-secrets-samples-ts",
+  "name": "@azure-samples/keyvault-secrets-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Key Vault Keys client library samples for TypeScript",

--- a/sdk/keyvault/keyvault-secrets/samples/v4/typescript/package.json
+++ b/sdk/keyvault/keyvault-secrets/samples/v4/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/keyvault-secrets-samples-ts",
+  "name": "@azure-samples/keyvault-secrets-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Key Vault Keys client library samples for TypeScript",

--- a/sdk/kusto/arm-kusto/samples/v7/javascript/package.json
+++ b/sdk/kusto/arm-kusto/samples/v7/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-kusto-samples-js",
+  "name": "@azure-samples/arm-kusto-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/kusto/arm-kusto/samples/v7/javascript/package.json
+++ b/sdk/kusto/arm-kusto/samples/v7/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-kusto-samples-js",
+  "name": "@azure-samples/arm-kusto-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/kusto/arm-kusto/samples/v7/typescript/package.json
+++ b/sdk/kusto/arm-kusto/samples/v7/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-kusto-samples-ts",
+  "name": "@azure-samples/arm-kusto-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/kusto/arm-kusto/samples/v7/typescript/package.json
+++ b/sdk/kusto/arm-kusto/samples/v7/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-kusto-samples-ts",
+  "name": "@azure-samples/arm-kusto-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/labservices/arm-labservices/samples/v3-beta/javascript/package.json
+++ b/sdk/labservices/arm-labservices/samples/v3-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-labservices-samples-js-beta",
+  "name": "@azure-samples/arm-labservices-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/labservices/arm-labservices/samples/v3-beta/javascript/package.json
+++ b/sdk/labservices/arm-labservices/samples/v3-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-labservices-samples-js-beta",
+  "name": "@azure-samples/arm-labservices-samples-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/labservices/arm-labservices/samples/v3-beta/typescript/package.json
+++ b/sdk/labservices/arm-labservices/samples/v3-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-labservices-samples-ts-beta",
+  "name": "@azure-samples/arm-labservices-samples-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/labservices/arm-labservices/samples/v3-beta/typescript/package.json
+++ b/sdk/labservices/arm-labservices/samples/v3-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-labservices-samples-ts-beta",
+  "name": "@azure-samples/arm-labservices-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/machinelearning/arm-workspaces/samples/v1/javascript/package.json
+++ b/sdk/machinelearning/arm-workspaces/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-workspaces-samples-js",
+  "name": "@azure-samples/arm-workspaces-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/machinelearning/arm-workspaces/samples/v1/javascript/package.json
+++ b/sdk/machinelearning/arm-workspaces/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-workspaces-samples-js",
+  "name": "@azure-samples/arm-workspaces-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/machinelearning/arm-workspaces/samples/v1/typescript/package.json
+++ b/sdk/machinelearning/arm-workspaces/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-workspaces-samples-ts",
+  "name": "@azure-samples/arm-workspaces-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/machinelearning/arm-workspaces/samples/v1/typescript/package.json
+++ b/sdk/machinelearning/arm-workspaces/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-workspaces-samples-ts",
+  "name": "@azure-samples/arm-workspaces-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/machinelearningcompute/arm-machinelearningcompute/samples/v3-beta/javascript/package.json
+++ b/sdk/machinelearningcompute/arm-machinelearningcompute/samples/v3-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-machinelearningcompute-samples-js-beta",
+  "name": "@azure-samples/arm-machinelearningcompute-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/machinelearningcompute/arm-machinelearningcompute/samples/v3-beta/javascript/package.json
+++ b/sdk/machinelearningcompute/arm-machinelearningcompute/samples/v3-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-machinelearningcompute-samples-js-beta",
+  "name": "@azure-samples/arm-machinelearningcompute-samples-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/machinelearningcompute/arm-machinelearningcompute/samples/v3-beta/typescript/package.json
+++ b/sdk/machinelearningcompute/arm-machinelearningcompute/samples/v3-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-machinelearningcompute-samples-ts-beta",
+  "name": "@azure-samples/arm-machinelearningcompute-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/machinelearningcompute/arm-machinelearningcompute/samples/v3-beta/typescript/package.json
+++ b/sdk/machinelearningcompute/arm-machinelearningcompute/samples/v3-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-machinelearningcompute-samples-ts-beta",
+  "name": "@azure-samples/arm-machinelearningcompute-samples-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/machinelearningexperimentation/arm-machinelearningexperimentation/samples/v2-beta/javascript/package.json
+++ b/sdk/machinelearningexperimentation/arm-machinelearningexperimentation/samples/v2-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-machinelearningexperimentation-samples-js-beta",
+  "name": "@azure-samples/arm-machinelearningexperimentation-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/machinelearningexperimentation/arm-machinelearningexperimentation/samples/v2-beta/javascript/package.json
+++ b/sdk/machinelearningexperimentation/arm-machinelearningexperimentation/samples/v2-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-machinelearningexperimentation-samples-js-beta",
+  "name": "@azure-samples/arm-machinelearningexperimentation-samples-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/machinelearningexperimentation/arm-machinelearningexperimentation/samples/v2-beta/typescript/package.json
+++ b/sdk/machinelearningexperimentation/arm-machinelearningexperimentation/samples/v2-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-machinelearningexperimentation-samples-ts-beta",
+  "name": "@azure-samples/arm-machinelearningexperimentation-samples-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/machinelearningexperimentation/arm-machinelearningexperimentation/samples/v2-beta/typescript/package.json
+++ b/sdk/machinelearningexperimentation/arm-machinelearningexperimentation/samples/v2-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-machinelearningexperimentation-samples-ts-beta",
+  "name": "@azure-samples/arm-machinelearningexperimentation-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/managementpartner/arm-managementpartner/samples/v2/javascript/package.json
+++ b/sdk/managementpartner/arm-managementpartner/samples/v2/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-managementpartner-samples-js",
+  "name": "@azure-samples/arm-managementpartner-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/managementpartner/arm-managementpartner/samples/v2/javascript/package.json
+++ b/sdk/managementpartner/arm-managementpartner/samples/v2/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-managementpartner-samples-js",
+  "name": "@azure-samples/arm-managementpartner-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/managementpartner/arm-managementpartner/samples/v2/typescript/package.json
+++ b/sdk/managementpartner/arm-managementpartner/samples/v2/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-managementpartner-samples-ts",
+  "name": "@azure-samples/arm-managementpartner-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/managementpartner/arm-managementpartner/samples/v2/typescript/package.json
+++ b/sdk/managementpartner/arm-managementpartner/samples/v2/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-managementpartner-samples-ts",
+  "name": "@azure-samples/arm-managementpartner-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/mariadb/arm-mariadb/samples/v2/javascript/package.json
+++ b/sdk/mariadb/arm-mariadb/samples/v2/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-mariadb-samples-js",
+  "name": "@azure-samples/arm-mariadb-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/mariadb/arm-mariadb/samples/v2/javascript/package.json
+++ b/sdk/mariadb/arm-mariadb/samples/v2/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-mariadb-samples-js",
+  "name": "@azure-samples/arm-mariadb-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/mariadb/arm-mariadb/samples/v2/typescript/package.json
+++ b/sdk/mariadb/arm-mariadb/samples/v2/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-mariadb-samples-ts",
+  "name": "@azure-samples/arm-mariadb-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/mariadb/arm-mariadb/samples/v2/typescript/package.json
+++ b/sdk/mariadb/arm-mariadb/samples/v2/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-mariadb-samples-ts",
+  "name": "@azure-samples/arm-mariadb-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/marketplaceordering/arm-marketplaceordering/samples/v3/javascript/package.json
+++ b/sdk/marketplaceordering/arm-marketplaceordering/samples/v3/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-marketplaceordering-samples-js",
+  "name": "@azure-samples/arm-marketplaceordering-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/marketplaceordering/arm-marketplaceordering/samples/v3/javascript/package.json
+++ b/sdk/marketplaceordering/arm-marketplaceordering/samples/v3/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-marketplaceordering-samples-js",
+  "name": "@azure-samples/arm-marketplaceordering-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/marketplaceordering/arm-marketplaceordering/samples/v3/typescript/package.json
+++ b/sdk/marketplaceordering/arm-marketplaceordering/samples/v3/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-marketplaceordering-samples-ts",
+  "name": "@azure-samples/arm-marketplaceordering-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/marketplaceordering/arm-marketplaceordering/samples/v3/typescript/package.json
+++ b/sdk/marketplaceordering/arm-marketplaceordering/samples/v3/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-marketplaceordering-samples-ts",
+  "name": "@azure-samples/arm-marketplaceordering-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/javascript/package.json
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-ai-metrics-advisor-samples-js",
+  "name": "@azure-samples/ai-metrics-advisor-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Metrics Advisor client library samples for JavaScript",

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/javascript/package.json
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/ai-metrics-advisor-samples-js",
+  "name": "@azure-samples/ai-metrics-advisor-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Metrics Advisor client library samples for JavaScript",

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/typescript/package.json
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-ai-metrics-advisor-samples-ts",
+  "name": "@azure-samples/ai-metrics-advisor-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Metrics Advisor client library samples for TypeScript",

--- a/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/typescript/package.json
+++ b/sdk/metricsadvisor/ai-metrics-advisor/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/ai-metrics-advisor-samples-ts",
+  "name": "@azure-samples/ai-metrics-advisor-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Metrics Advisor client library samples for TypeScript",

--- a/sdk/migrate/arm-migrate/samples/v2/javascript/package.json
+++ b/sdk/migrate/arm-migrate/samples/v2/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-migrate-samples-js",
+  "name": "@azure-samples/arm-migrate-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/migrate/arm-migrate/samples/v2/javascript/package.json
+++ b/sdk/migrate/arm-migrate/samples/v2/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-migrate-samples-js",
+  "name": "@azure-samples/arm-migrate-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/migrate/arm-migrate/samples/v2/typescript/package.json
+++ b/sdk/migrate/arm-migrate/samples/v2/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-migrate-samples-ts",
+  "name": "@azure-samples/arm-migrate-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/migrate/arm-migrate/samples/v2/typescript/package.json
+++ b/sdk/migrate/arm-migrate/samples/v2/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-migrate-samples-ts",
+  "name": "@azure-samples/arm-migrate-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/mixedreality/arm-mixedreality/samples/v4/javascript/package.json
+++ b/sdk/mixedreality/arm-mixedreality/samples/v4/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-mixedreality-samples-js",
+  "name": "@azure-samples/arm-mixedreality-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/mixedreality/arm-mixedreality/samples/v4/javascript/package.json
+++ b/sdk/mixedreality/arm-mixedreality/samples/v4/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-mixedreality-samples-js",
+  "name": "@azure-samples/arm-mixedreality-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/mixedreality/arm-mixedreality/samples/v4/typescript/package.json
+++ b/sdk/mixedreality/arm-mixedreality/samples/v4/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-mixedreality-samples-ts",
+  "name": "@azure-samples/arm-mixedreality-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/mixedreality/arm-mixedreality/samples/v4/typescript/package.json
+++ b/sdk/mixedreality/arm-mixedreality/samples/v4/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-mixedreality-samples-ts",
+  "name": "@azure-samples/arm-mixedreality-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/mixedreality/mixed-reality-authentication/samples/v1/javascript/package.json
+++ b/sdk/mixedreality/mixed-reality-authentication/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/mixed-reality-authentication-samples-js",
+  "name": "@azure-samples/mixed-reality-authentication-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Mixed Reality Authentication client library samples for JavaScript",

--- a/sdk/mixedreality/mixed-reality-authentication/samples/v1/javascript/package.json
+++ b/sdk/mixedreality/mixed-reality-authentication/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-mixed-reality-authentication-samples-js",
+  "name": "@azure-samples/mixed-reality-authentication-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Mixed Reality Authentication client library samples for JavaScript",

--- a/sdk/mixedreality/mixed-reality-authentication/samples/v1/typescript/package.json
+++ b/sdk/mixedreality/mixed-reality-authentication/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-mixed-reality-authentication-samples-ts",
+  "name": "@azure-samples/mixed-reality-authentication-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Mixed Reality Authentication client library samples for TypeScript",

--- a/sdk/mixedreality/mixed-reality-authentication/samples/v1/typescript/package.json
+++ b/sdk/mixedreality/mixed-reality-authentication/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/mixed-reality-authentication-samples-ts",
+  "name": "@azure-samples/mixed-reality-authentication-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Mixed Reality Authentication client library samples for TypeScript",

--- a/sdk/mobilenetwork/arm-mobilenetwork/samples/v1-beta/javascript/package.json
+++ b/sdk/mobilenetwork/arm-mobilenetwork/samples/v1-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-mobilenetwork-samples-js-beta",
+  "name": "@azure-samples/arm-mobilenetwork-samples-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/mobilenetwork/arm-mobilenetwork/samples/v1-beta/javascript/package.json
+++ b/sdk/mobilenetwork/arm-mobilenetwork/samples/v1-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-mobilenetwork-samples-js-beta",
+  "name": "@azure-samples/arm-mobilenetwork-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/mobilenetwork/arm-mobilenetwork/samples/v1-beta/typescript/package.json
+++ b/sdk/mobilenetwork/arm-mobilenetwork/samples/v1-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-mobilenetwork-samples-ts-beta",
+  "name": "@azure-samples/arm-mobilenetwork-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/mobilenetwork/arm-mobilenetwork/samples/v1-beta/typescript/package.json
+++ b/sdk/mobilenetwork/arm-mobilenetwork/samples/v1-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-mobilenetwork-samples-ts-beta",
+  "name": "@azure-samples/arm-mobilenetwork-samples-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/monitor/monitor-opentelemetry-exporter/samples/v1/javascript/package.json
+++ b/sdk/monitor/monitor-opentelemetry-exporter/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/monitor-opentelemetry-exporter-samples-js",
+  "name": "@azure-samples/monitor-opentelemetry-exporter-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Monitor Trace Exporter client library samples for JavaScript",

--- a/sdk/monitor/monitor-opentelemetry-exporter/samples/v1/javascript/package.json
+++ b/sdk/monitor/monitor-opentelemetry-exporter/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-monitor-opentelemetry-exporter-samples-js",
+  "name": "@azure-samples/monitor-opentelemetry-exporter-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Monitor Trace Exporter client library samples for JavaScript",

--- a/sdk/monitor/monitor-opentelemetry-exporter/samples/v1/typescript/package.json
+++ b/sdk/monitor/monitor-opentelemetry-exporter/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/monitor-opentelemetry-exporter-samples-ts",
+  "name": "@azure-samples/monitor-opentelemetry-exporter-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Monitor Trace Exporter client library samples for TypeScript",

--- a/sdk/monitor/monitor-opentelemetry-exporter/samples/v1/typescript/package.json
+++ b/sdk/monitor/monitor-opentelemetry-exporter/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-monitor-opentelemetry-exporter-samples-ts",
+  "name": "@azure-samples/monitor-opentelemetry-exporter-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Monitor Trace Exporter client library samples for TypeScript",

--- a/sdk/monitor/monitor-query/samples/v1/javascript/package.json
+++ b/sdk/monitor/monitor-query/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/monitor-query-samples-js",
+  "name": "@azure-samples/monitor-query-js",
   "private": true,
   "version": "1.0.0",
   "description": "Monitor Query client library samples for JavaScript",

--- a/sdk/monitor/monitor-query/samples/v1/javascript/package.json
+++ b/sdk/monitor/monitor-query/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-monitor-query-samples-js",
+  "name": "@azure-samples/monitor-query-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Monitor Query client library samples for JavaScript",

--- a/sdk/monitor/monitor-query/samples/v1/typescript/package.json
+++ b/sdk/monitor/monitor-query/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-monitor-query-samples-ts",
+  "name": "@azure-samples/monitor-query-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Monitor Query client library samples for TypeScript",

--- a/sdk/monitor/monitor-query/samples/v1/typescript/package.json
+++ b/sdk/monitor/monitor-query/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/monitor-query-samples-ts",
+  "name": "@azure-samples/monitor-query-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Monitor Query client library samples for TypeScript",

--- a/sdk/msi/arm-msi/samples/v2-beta/javascript/package.json
+++ b/sdk/msi/arm-msi/samples/v2-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-msi-samples-js-beta",
+  "name": "@azure-samples/arm-msi-samples-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/msi/arm-msi/samples/v2-beta/javascript/package.json
+++ b/sdk/msi/arm-msi/samples/v2-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-msi-samples-js-beta",
+  "name": "@azure-samples/arm-msi-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/msi/arm-msi/samples/v2-beta/typescript/package.json
+++ b/sdk/msi/arm-msi/samples/v2-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-msi-samples-ts-beta",
+  "name": "@azure-samples/arm-msi-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/msi/arm-msi/samples/v2-beta/typescript/package.json
+++ b/sdk/msi/arm-msi/samples/v2-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-msi-samples-ts-beta",
+  "name": "@azure-samples/arm-msi-samples-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/mysql/arm-mysql-flexible/samples/v2/javascript/package.json
+++ b/sdk/mysql/arm-mysql-flexible/samples/v2/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-mysql-flexible-samples-js",
+  "name": "@azure-samples/arm-mysql-flexible-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/mysql/arm-mysql-flexible/samples/v2/javascript/package.json
+++ b/sdk/mysql/arm-mysql-flexible/samples/v2/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-mysql-flexible-samples-js",
+  "name": "@azure-samples/arm-mysql-flexible-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/mysql/arm-mysql-flexible/samples/v2/typescript/package.json
+++ b/sdk/mysql/arm-mysql-flexible/samples/v2/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-mysql-flexible-samples-ts",
+  "name": "@azure-samples/arm-mysql-flexible-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/mysql/arm-mysql-flexible/samples/v2/typescript/package.json
+++ b/sdk/mysql/arm-mysql-flexible/samples/v2/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-mysql-flexible-samples-ts",
+  "name": "@azure-samples/arm-mysql-flexible-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/netapp/arm-netapp/samples/v15/javascript/package.json
+++ b/sdk/netapp/arm-netapp/samples/v15/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-netapp-samples-js",
+  "name": "@azure-samples/arm-netapp-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/netapp/arm-netapp/samples/v15/javascript/package.json
+++ b/sdk/netapp/arm-netapp/samples/v15/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-netapp-samples-js",
+  "name": "@azure-samples/arm-netapp-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/netapp/arm-netapp/samples/v15/typescript/package.json
+++ b/sdk/netapp/arm-netapp/samples/v15/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-netapp-samples-ts",
+  "name": "@azure-samples/arm-netapp-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/netapp/arm-netapp/samples/v15/typescript/package.json
+++ b/sdk/netapp/arm-netapp/samples/v15/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-netapp-samples-ts",
+  "name": "@azure-samples/arm-netapp-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/oep/arm-oep/samples/v1-beta/javascript/package.json
+++ b/sdk/oep/arm-oep/samples/v1-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-oep-samples-js-beta",
+  "name": "@azure-samples/arm-oep-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/oep/arm-oep/samples/v1-beta/javascript/package.json
+++ b/sdk/oep/arm-oep/samples/v1-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-oep-samples-js-beta",
+  "name": "@azure-samples/arm-oep-samples-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/oep/arm-oep/samples/v1-beta/typescript/package.json
+++ b/sdk/oep/arm-oep/samples/v1-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-oep-samples-ts-beta",
+  "name": "@azure-samples/arm-oep-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/oep/arm-oep/samples/v1-beta/typescript/package.json
+++ b/sdk/oep/arm-oep/samples/v1-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-oep-samples-ts-beta",
+  "name": "@azure-samples/arm-oep-samples-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/peering/arm-peering/samples/v2/javascript/package.json
+++ b/sdk/peering/arm-peering/samples/v2/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-peering-samples-js",
+  "name": "@azure-samples/arm-peering-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/peering/arm-peering/samples/v2/javascript/package.json
+++ b/sdk/peering/arm-peering/samples/v2/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-peering-samples-js",
+  "name": "@azure-samples/arm-peering-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/peering/arm-peering/samples/v2/typescript/package.json
+++ b/sdk/peering/arm-peering/samples/v2/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-peering-samples-ts",
+  "name": "@azure-samples/arm-peering-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/peering/arm-peering/samples/v2/typescript/package.json
+++ b/sdk/peering/arm-peering/samples/v2/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-peering-samples-ts",
+  "name": "@azure-samples/arm-peering-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/policyinsights/arm-policyinsights/samples/v5/javascript/package.json
+++ b/sdk/policyinsights/arm-policyinsights/samples/v5/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-policyinsights-samples-js",
+  "name": "@azure-samples/arm-policyinsights-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/policyinsights/arm-policyinsights/samples/v5/javascript/package.json
+++ b/sdk/policyinsights/arm-policyinsights/samples/v5/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-policyinsights-samples-js",
+  "name": "@azure-samples/arm-policyinsights-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/policyinsights/arm-policyinsights/samples/v5/typescript/package.json
+++ b/sdk/policyinsights/arm-policyinsights/samples/v5/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-policyinsights-samples-ts",
+  "name": "@azure-samples/arm-policyinsights-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/policyinsights/arm-policyinsights/samples/v5/typescript/package.json
+++ b/sdk/policyinsights/arm-policyinsights/samples/v5/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-policyinsights-samples-ts",
+  "name": "@azure-samples/arm-policyinsights-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/postgresql/arm-postgresql-flexible/samples/v5/javascript/package.json
+++ b/sdk/postgresql/arm-postgresql-flexible/samples/v5/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-postgresql-flexible-samples-js",
+  "name": "@azure-samples/arm-postgresql-flexible-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/postgresql/arm-postgresql-flexible/samples/v5/javascript/package.json
+++ b/sdk/postgresql/arm-postgresql-flexible/samples/v5/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-postgresql-flexible-samples-js",
+  "name": "@azure-samples/arm-postgresql-flexible-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/postgresql/arm-postgresql-flexible/samples/v5/typescript/package.json
+++ b/sdk/postgresql/arm-postgresql-flexible/samples/v5/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-postgresql-flexible-samples-ts",
+  "name": "@azure-samples/arm-postgresql-flexible-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/postgresql/arm-postgresql-flexible/samples/v5/typescript/package.json
+++ b/sdk/postgresql/arm-postgresql-flexible/samples/v5/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-postgresql-flexible-samples-ts",
+  "name": "@azure-samples/arm-postgresql-flexible-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/powerbidedicated/arm-powerbidedicated/samples/v3/javascript/package.json
+++ b/sdk/powerbidedicated/arm-powerbidedicated/samples/v3/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-powerbidedicated-samples-js",
+  "name": "@azure-samples/arm-powerbidedicated-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/powerbidedicated/arm-powerbidedicated/samples/v3/javascript/package.json
+++ b/sdk/powerbidedicated/arm-powerbidedicated/samples/v3/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-powerbidedicated-samples-js",
+  "name": "@azure-samples/arm-powerbidedicated-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/powerbidedicated/arm-powerbidedicated/samples/v3/typescript/package.json
+++ b/sdk/powerbidedicated/arm-powerbidedicated/samples/v3/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-powerbidedicated-samples-ts",
+  "name": "@azure-samples/arm-powerbidedicated-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/powerbidedicated/arm-powerbidedicated/samples/v3/typescript/package.json
+++ b/sdk/powerbidedicated/arm-powerbidedicated/samples/v3/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-powerbidedicated-samples-ts",
+  "name": "@azure-samples/arm-powerbidedicated-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/privatedns/arm-privatedns/samples/v3/javascript/package.json
+++ b/sdk/privatedns/arm-privatedns/samples/v3/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-privatedns-samples-js",
+  "name": "@azure-samples/arm-privatedns-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/privatedns/arm-privatedns/samples/v3/javascript/package.json
+++ b/sdk/privatedns/arm-privatedns/samples/v3/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-privatedns-samples-js",
+  "name": "@azure-samples/arm-privatedns-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/privatedns/arm-privatedns/samples/v3/typescript/package.json
+++ b/sdk/privatedns/arm-privatedns/samples/v3/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-privatedns-samples-ts",
+  "name": "@azure-samples/arm-privatedns-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/privatedns/arm-privatedns/samples/v3/typescript/package.json
+++ b/sdk/privatedns/arm-privatedns/samples/v3/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-privatedns-samples-ts",
+  "name": "@azure-samples/arm-privatedns-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/purview/purview-administration-rest/samples/v1/javascript/package.json
+++ b/sdk/purview/purview-administration-rest/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-purview-administration-samples-js",
+  "name": "@azure-samples/purview-administration-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Purview Administration rest client library samples for JavaScript",

--- a/sdk/purview/purview-administration-rest/samples/v1/javascript/package.json
+++ b/sdk/purview/purview-administration-rest/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/purview-administration-samples-js",
+  "name": "@azure-samples/purview-administration-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Purview Administration rest client library samples for JavaScript",

--- a/sdk/purview/purview-administration-rest/samples/v1/typescript/package.json
+++ b/sdk/purview/purview-administration-rest/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/purview-administration-samples-ts",
+  "name": "@azure-samples/purview-administration-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Purview Administration rest client library samples for TypeScript",

--- a/sdk/purview/purview-administration-rest/samples/v1/typescript/package.json
+++ b/sdk/purview/purview-administration-rest/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-purview-administration-samples-ts",
+  "name": "@azure-samples/purview-administration-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Purview Administration rest client library samples for TypeScript",

--- a/sdk/purview/purview-catalog-rest/samples/v1/javascript/package.json
+++ b/sdk/purview/purview-catalog-rest/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-purview-catalog-samples-js",
+  "name": "@azure-samples/purview-catalog-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Purview Scanning rest client library samples for JavaScript",

--- a/sdk/purview/purview-catalog-rest/samples/v1/javascript/package.json
+++ b/sdk/purview/purview-catalog-rest/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/purview-catalog-samples-js",
+  "name": "@azure-samples/purview-catalog-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Purview Scanning rest client library samples for JavaScript",

--- a/sdk/purview/purview-catalog-rest/samples/v1/typescript/package.json
+++ b/sdk/purview/purview-catalog-rest/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/purview-catalog-samples-ts",
+  "name": "@azure-samples/purview-catalog-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Purview Scanning rest client library samples for TypeScript",

--- a/sdk/purview/purview-catalog-rest/samples/v1/typescript/package.json
+++ b/sdk/purview/purview-catalog-rest/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-purview-catalog-samples-ts",
+  "name": "@azure-samples/purview-catalog-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Purview Scanning rest client library samples for TypeScript",

--- a/sdk/purview/purview-scanning-rest/samples/v1/javascript/package.json
+++ b/sdk/purview/purview-scanning-rest/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-purview-scanning-samples-js",
+  "name": "@azure-samples/purview-scanning-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Purview Scanning rest client library samples for JavaScript",

--- a/sdk/purview/purview-scanning-rest/samples/v1/javascript/package.json
+++ b/sdk/purview/purview-scanning-rest/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/purview-scanning-samples-js",
+  "name": "@azure-samples/purview-scanning-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Purview Scanning rest client library samples for JavaScript",

--- a/sdk/purview/purview-scanning-rest/samples/v1/typescript/package.json
+++ b/sdk/purview/purview-scanning-rest/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/purview-scanning-samples-ts",
+  "name": "@azure-samples/purview-scanning-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Purview Scanning rest client library samples for TypeScript",

--- a/sdk/purview/purview-scanning-rest/samples/v1/typescript/package.json
+++ b/sdk/purview/purview-scanning-rest/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-purview-scanning-samples-ts",
+  "name": "@azure-samples/purview-scanning-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Purview Scanning rest client library samples for TypeScript",

--- a/sdk/quantum/quantum-jobs/samples/package.json
+++ b/sdk/quantum/quantum-jobs/samples/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-quantum-jobs-samples-js",
+  "name": "@azure-samples/quantum-jobs-samples-js",
   "private": true,
   "version": "1.0.0-beta.1",
   "description": "Samples for the azure/quantum-jobs client library for Javascript",

--- a/sdk/quantum/quantum-jobs/samples/package.json
+++ b/sdk/quantum/quantum-jobs/samples/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/quantum-jobs-samples-js",
+  "name": "@azure-samples/quantum-jobs-js",
   "private": true,
   "version": "1.0.0-beta.1",
   "description": "Samples for the azure/quantum-jobs client library for Javascript",

--- a/sdk/recoveryservicesbackup/arm-recoveryservicesbackup/samples/v8/javascript/package.json
+++ b/sdk/recoveryservicesbackup/arm-recoveryservicesbackup/samples/v8/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-recoveryservicesbackup-samples-js",
+  "name": "@azure-samples/arm-recoveryservicesbackup-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/recoveryservicesbackup/arm-recoveryservicesbackup/samples/v8/javascript/package.json
+++ b/sdk/recoveryservicesbackup/arm-recoveryservicesbackup/samples/v8/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-recoveryservicesbackup-samples-js",
+  "name": "@azure-samples/arm-recoveryservicesbackup-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/recoveryservicesbackup/arm-recoveryservicesbackup/samples/v8/typescript/package.json
+++ b/sdk/recoveryservicesbackup/arm-recoveryservicesbackup/samples/v8/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-recoveryservicesbackup-samples-ts",
+  "name": "@azure-samples/arm-recoveryservicesbackup-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/recoveryservicesbackup/arm-recoveryservicesbackup/samples/v8/typescript/package.json
+++ b/sdk/recoveryservicesbackup/arm-recoveryservicesbackup/samples/v8/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-recoveryservicesbackup-samples-ts",
+  "name": "@azure-samples/arm-recoveryservicesbackup-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/redis/arm-rediscache/samples/v1-beta/javascript/package.json
+++ b/sdk/redis/arm-rediscache/samples/v1-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-rediscache-samples-js-beta",
+  "name": "@azure-samples/arm-rediscache-samples-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/redis/arm-rediscache/samples/v1-beta/javascript/package.json
+++ b/sdk/redis/arm-rediscache/samples/v1-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-rediscache-samples-js-beta",
+  "name": "@azure-samples/arm-rediscache-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/redis/arm-rediscache/samples/v1-beta/typescript/package.json
+++ b/sdk/redis/arm-rediscache/samples/v1-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-rediscache-samples-ts-beta",
+  "name": "@azure-samples/arm-rediscache-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/redis/arm-rediscache/samples/v1-beta/typescript/package.json
+++ b/sdk/redis/arm-rediscache/samples/v1-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-rediscache-samples-ts-beta",
+  "name": "@azure-samples/arm-rediscache-samples-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/redis/arm-rediscache/samples/v6/javascript/package.json
+++ b/sdk/redis/arm-rediscache/samples/v6/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-rediscache-samples-js",
+  "name": "@azure-samples/arm-rediscache-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/redis/arm-rediscache/samples/v6/javascript/package.json
+++ b/sdk/redis/arm-rediscache/samples/v6/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-rediscache-samples-js",
+  "name": "@azure-samples/arm-rediscache-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/redis/arm-rediscache/samples/v6/typescript/package.json
+++ b/sdk/redis/arm-rediscache/samples/v6/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-rediscache-samples-ts",
+  "name": "@azure-samples/arm-rediscache-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/redis/arm-rediscache/samples/v6/typescript/package.json
+++ b/sdk/redis/arm-rediscache/samples/v6/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-rediscache-samples-ts",
+  "name": "@azure-samples/arm-rediscache-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/redisenterprise/arm-redisenterprisecache/samples/v2/javascript/package.json
+++ b/sdk/redisenterprise/arm-redisenterprisecache/samples/v2/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-redisenterprisecache-samples-js",
+  "name": "@azure-samples/arm-redisenterprisecache-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/redisenterprise/arm-redisenterprisecache/samples/v2/javascript/package.json
+++ b/sdk/redisenterprise/arm-redisenterprisecache/samples/v2/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-redisenterprisecache-samples-js",
+  "name": "@azure-samples/arm-redisenterprisecache-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/redisenterprise/arm-redisenterprisecache/samples/v2/typescript/package.json
+++ b/sdk/redisenterprise/arm-redisenterprisecache/samples/v2/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-redisenterprisecache-samples-ts",
+  "name": "@azure-samples/arm-redisenterprisecache-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/redisenterprise/arm-redisenterprisecache/samples/v2/typescript/package.json
+++ b/sdk/redisenterprise/arm-redisenterprisecache/samples/v2/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-redisenterprisecache-samples-ts",
+  "name": "@azure-samples/arm-redisenterprisecache-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/reservations/arm-reservations/samples/v7/javascript/package.json
+++ b/sdk/reservations/arm-reservations/samples/v7/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-reservations-samples-js",
+  "name": "@azure-samples/arm-reservations-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/reservations/arm-reservations/samples/v7/javascript/package.json
+++ b/sdk/reservations/arm-reservations/samples/v7/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-reservations-samples-js",
+  "name": "@azure-samples/arm-reservations-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/reservations/arm-reservations/samples/v7/typescript/package.json
+++ b/sdk/reservations/arm-reservations/samples/v7/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-reservations-samples-ts",
+  "name": "@azure-samples/arm-reservations-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/reservations/arm-reservations/samples/v7/typescript/package.json
+++ b/sdk/reservations/arm-reservations/samples/v7/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-reservations-samples-ts",
+  "name": "@azure-samples/arm-reservations-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/resourcegraph/arm-resourcegraph/samples/v5-beta/javascript/package.json
+++ b/sdk/resourcegraph/arm-resourcegraph/samples/v5-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-resourcegraph-samples-js-beta",
+  "name": "@azure-samples/arm-resourcegraph-samples-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/resourcegraph/arm-resourcegraph/samples/v5-beta/javascript/package.json
+++ b/sdk/resourcegraph/arm-resourcegraph/samples/v5-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-resourcegraph-samples-js-beta",
+  "name": "@azure-samples/arm-resourcegraph-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/resourcegraph/arm-resourcegraph/samples/v5-beta/typescript/package.json
+++ b/sdk/resourcegraph/arm-resourcegraph/samples/v5-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-resourcegraph-samples-ts-beta",
+  "name": "@azure-samples/arm-resourcegraph-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/resourcegraph/arm-resourcegraph/samples/v5-beta/typescript/package.json
+++ b/sdk/resourcegraph/arm-resourcegraph/samples/v5-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-resourcegraph-samples-ts-beta",
+  "name": "@azure-samples/arm-resourcegraph-samples-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/resourcemover/arm-resourcemover/samples/v2/javascript/package.json
+++ b/sdk/resourcemover/arm-resourcemover/samples/v2/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-resourcemover-samples-js",
+  "name": "@azure-samples/arm-resourcemover-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/resourcemover/arm-resourcemover/samples/v2/javascript/package.json
+++ b/sdk/resourcemover/arm-resourcemover/samples/v2/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-resourcemover-samples-js",
+  "name": "@azure-samples/arm-resourcemover-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/resourcemover/arm-resourcemover/samples/v2/typescript/package.json
+++ b/sdk/resourcemover/arm-resourcemover/samples/v2/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-resourcemover-samples-ts",
+  "name": "@azure-samples/arm-resourcemover-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/resourcemover/arm-resourcemover/samples/v2/typescript/package.json
+++ b/sdk/resourcemover/arm-resourcemover/samples/v2/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-resourcemover-samples-ts",
+  "name": "@azure-samples/arm-resourcemover-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/schemaregistry/schema-registry-avro/samples/v1-beta/javascript/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/samples/v1-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/schema-registry-avro-samples-js-beta",
+  "name": "@azure-samples/schema-registry-avro-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Schema Registry client library samples for JavaScript (Beta)",

--- a/sdk/schemaregistry/schema-registry-avro/samples/v1-beta/javascript/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/samples/v1-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-schema-registry-avro-samples-js-beta",
+  "name": "@azure-samples/schema-registry-avro-samples-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Schema Registry client library samples for JavaScript (Beta)",

--- a/sdk/schemaregistry/schema-registry-avro/samples/v1-beta/typescript/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/samples/v1-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-schema-registry-avro-samples-ts-beta",
+  "name": "@azure-samples/schema-registry-avro-samples-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Schema Registry client library samples for TypeScript (Beta)",

--- a/sdk/schemaregistry/schema-registry-avro/samples/v1-beta/typescript/package.json
+++ b/sdk/schemaregistry/schema-registry-avro/samples/v1-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/schema-registry-avro-samples-ts-beta",
+  "name": "@azure-samples/schema-registry-avro-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Schema Registry client library samples for TypeScript (Beta)",

--- a/sdk/schemaregistry/schema-registry/samples/v1/javascript/package.json
+++ b/sdk/schemaregistry/schema-registry/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-schema-registry-samples-js",
+  "name": "@azure-samples/schema-registry-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Schema Registry client library samples for JavaScript",

--- a/sdk/schemaregistry/schema-registry/samples/v1/javascript/package.json
+++ b/sdk/schemaregistry/schema-registry/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/schema-registry-samples-js",
+  "name": "@azure-samples/schema-registry-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Schema Registry client library samples for JavaScript",

--- a/sdk/schemaregistry/schema-registry/samples/v1/typescript/package.json
+++ b/sdk/schemaregistry/schema-registry/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-schema-registry-samples-ts",
+  "name": "@azure-samples/schema-registry-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Schema Registry client library samples for TypeScript",

--- a/sdk/schemaregistry/schema-registry/samples/v1/typescript/package.json
+++ b/sdk/schemaregistry/schema-registry/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/schema-registry-samples-ts",
+  "name": "@azure-samples/schema-registry-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Schema Registry client library samples for TypeScript",

--- a/sdk/search/search-documents/samples/v11/javascript/package.json
+++ b/sdk/search/search-documents/samples/v11/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-search-documents-samples-js",
+  "name": "@azure-samples/search-documents-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Search Documents client library samples for JavaScript",

--- a/sdk/search/search-documents/samples/v11/javascript/package.json
+++ b/sdk/search/search-documents/samples/v11/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/search-documents-samples-js",
+  "name": "@azure-samples/search-documents-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Search Documents client library samples for JavaScript",

--- a/sdk/search/search-documents/samples/v11/typescript/package.json
+++ b/sdk/search/search-documents/samples/v11/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/search-documents-samples-ts",
+  "name": "@azure-samples/search-documents-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Search Documents client library samples for TypeScript",

--- a/sdk/search/search-documents/samples/v11/typescript/package.json
+++ b/sdk/search/search-documents/samples/v11/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-search-documents-samples-ts",
+  "name": "@azure-samples/search-documents-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Search Documents client library samples for TypeScript",

--- a/sdk/securityinsight/arm-securityinsight/samples/v1-beta/javascript/package.json
+++ b/sdk/securityinsight/arm-securityinsight/samples/v1-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-securityinsight-samples-js-beta",
+  "name": "@azure-samples/arm-securityinsight-samples-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/securityinsight/arm-securityinsight/samples/v1-beta/javascript/package.json
+++ b/sdk/securityinsight/arm-securityinsight/samples/v1-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-securityinsight-samples-js-beta",
+  "name": "@azure-samples/arm-securityinsight-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/securityinsight/arm-securityinsight/samples/v1-beta/typescript/package.json
+++ b/sdk/securityinsight/arm-securityinsight/samples/v1-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-securityinsight-samples-ts-beta",
+  "name": "@azure-samples/arm-securityinsight-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/securityinsight/arm-securityinsight/samples/v1-beta/typescript/package.json
+++ b/sdk/securityinsight/arm-securityinsight/samples/v1-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-securityinsight-samples-ts-beta",
+  "name": "@azure-samples/arm-securityinsight-samples-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/service-map/arm-servicemap/samples/v3-beta/javascript/package.json
+++ b/sdk/service-map/arm-servicemap/samples/v3-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-servicemap-samples-js-beta",
+  "name": "@azure-samples/arm-servicemap-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/service-map/arm-servicemap/samples/v3-beta/javascript/package.json
+++ b/sdk/service-map/arm-servicemap/samples/v3-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-servicemap-samples-js-beta",
+  "name": "@azure-samples/arm-servicemap-samples-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/service-map/arm-servicemap/samples/v3-beta/typescript/package.json
+++ b/sdk/service-map/arm-servicemap/samples/v3-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-servicemap-samples-ts-beta",
+  "name": "@azure-samples/arm-servicemap-samples-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/service-map/arm-servicemap/samples/v3-beta/typescript/package.json
+++ b/sdk/service-map/arm-servicemap/samples/v3-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-servicemap-samples-ts-beta",
+  "name": "@azure-samples/arm-servicemap-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/servicebus/service-bus/samples/v7/javascript/package.json
+++ b/sdk/servicebus/service-bus/samples/v7/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/service-bus-samples-js",
+  "name": "@azure-samples/service-bus-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Service Bus client library samples for JavaScript",

--- a/sdk/servicebus/service-bus/samples/v7/javascript/package.json
+++ b/sdk/servicebus/service-bus/samples/v7/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-service-bus-samples-js",
+  "name": "@azure-samples/service-bus-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Service Bus client library samples for JavaScript",

--- a/sdk/servicebus/service-bus/samples/v7/typescript/package.json
+++ b/sdk/servicebus/service-bus/samples/v7/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-service-bus-samples-ts",
+  "name": "@azure-samples/service-bus-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Service Bus client library samples for TypeScript",

--- a/sdk/servicebus/service-bus/samples/v7/typescript/package.json
+++ b/sdk/servicebus/service-bus/samples/v7/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/service-bus-samples-ts",
+  "name": "@azure-samples/service-bus-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Service Bus client library samples for TypeScript",

--- a/sdk/servicefabricmesh/arm-servicefabricmesh/samples/v3-beta/javascript/package.json
+++ b/sdk/servicefabricmesh/arm-servicefabricmesh/samples/v3-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-servicefabricmesh-samples-js-beta",
+  "name": "@azure-samples/arm-servicefabricmesh-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/servicefabricmesh/arm-servicefabricmesh/samples/v3-beta/javascript/package.json
+++ b/sdk/servicefabricmesh/arm-servicefabricmesh/samples/v3-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-servicefabricmesh-samples-js-beta",
+  "name": "@azure-samples/arm-servicefabricmesh-samples-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/servicefabricmesh/arm-servicefabricmesh/samples/v3-beta/typescript/package.json
+++ b/sdk/servicefabricmesh/arm-servicefabricmesh/samples/v3-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-servicefabricmesh-samples-ts-beta",
+  "name": "@azure-samples/arm-servicefabricmesh-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/servicefabricmesh/arm-servicefabricmesh/samples/v3-beta/typescript/package.json
+++ b/sdk/servicefabricmesh/arm-servicefabricmesh/samples/v3-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-servicefabricmesh-samples-ts-beta",
+  "name": "@azure-samples/arm-servicefabricmesh-samples-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/signalr/arm-signalr/samples/v5/javascript/package.json
+++ b/sdk/signalr/arm-signalr/samples/v5/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-signalr-samples-js",
+  "name": "@azure-samples/arm-signalr-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/signalr/arm-signalr/samples/v5/javascript/package.json
+++ b/sdk/signalr/arm-signalr/samples/v5/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-signalr-samples-js",
+  "name": "@azure-samples/arm-signalr-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/signalr/arm-signalr/samples/v5/typescript/package.json
+++ b/sdk/signalr/arm-signalr/samples/v5/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-signalr-samples-ts",
+  "name": "@azure-samples/arm-signalr-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/signalr/arm-signalr/samples/v5/typescript/package.json
+++ b/sdk/signalr/arm-signalr/samples/v5/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-signalr-samples-ts",
+  "name": "@azure-samples/arm-signalr-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/storage/arm-storage/samples/v17/javascript/package.json
+++ b/sdk/storage/arm-storage/samples/v17/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-storage-samples-js",
+  "name": "@azure-samples/arm-storage-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/storage/arm-storage/samples/v17/javascript/package.json
+++ b/sdk/storage/arm-storage/samples/v17/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-storage-samples-js",
+  "name": "@azure-samples/arm-storage-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/storage/arm-storage/samples/v17/typescript/package.json
+++ b/sdk/storage/arm-storage/samples/v17/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-storage-samples-ts",
+  "name": "@azure-samples/arm-storage-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/storage/arm-storage/samples/v17/typescript/package.json
+++ b/sdk/storage/arm-storage/samples/v17/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-storage-samples-ts",
+  "name": "@azure-samples/arm-storage-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/storage/storage-blob-changefeed/samples/v12-beta/javascript/package.json
+++ b/sdk/storage/storage-blob-changefeed/samples/v12-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/storage-blob-changefeed-samples-js-beta",
+  "name": "@azure-samples/storage-blob-changefeed-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Storage Blob Change Feed client library samples for JavaScript (Beta)",

--- a/sdk/storage/storage-blob-changefeed/samples/v12-beta/javascript/package.json
+++ b/sdk/storage/storage-blob-changefeed/samples/v12-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-storage-blob-changefeed-samples-js-beta",
+  "name": "@azure-samples/storage-blob-changefeed-samples-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Storage Blob Change Feed client library samples for JavaScript (Beta)",

--- a/sdk/storage/storage-blob-changefeed/samples/v12-beta/typescript/package.json
+++ b/sdk/storage/storage-blob-changefeed/samples/v12-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-storage-blob-changefeed-samples-ts-beta",
+  "name": "@azure-samples/storage-blob-changefeed-samples-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Storage Blob Change Feed client library samples for TypeScript (Beta)",

--- a/sdk/storage/storage-blob-changefeed/samples/v12-beta/typescript/package.json
+++ b/sdk/storage/storage-blob-changefeed/samples/v12-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/storage-blob-changefeed-samples-ts-beta",
+  "name": "@azure-samples/storage-blob-changefeed-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Storage Blob Change Feed client library samples for TypeScript (Beta)",

--- a/sdk/storage/storage-blob/samples/v12/javascript/package.json
+++ b/sdk/storage/storage-blob/samples/v12/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-storage-blob-samples-js",
+  "name": "@azure-samples/storage-blob-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Storage Blob client library samples for JavaScript",

--- a/sdk/storage/storage-blob/samples/v12/javascript/package.json
+++ b/sdk/storage/storage-blob/samples/v12/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/storage-blob-samples-js",
+  "name": "@azure-samples/storage-blob-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Storage Blob client library samples for JavaScript",

--- a/sdk/storage/storage-blob/samples/v12/typescript/package.json
+++ b/sdk/storage/storage-blob/samples/v12/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/storage-blob-samples-ts",
+  "name": "@azure-samples/storage-blob-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Storage Blob client library samples for TypeScript",

--- a/sdk/storage/storage-blob/samples/v12/typescript/package.json
+++ b/sdk/storage/storage-blob/samples/v12/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-storage-blob-samples-ts",
+  "name": "@azure-samples/storage-blob-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Storage Blob client library samples for TypeScript",

--- a/sdk/storage/storage-file-datalake/samples/v12/javascript/package.json
+++ b/sdk/storage/storage-file-datalake/samples/v12/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/storage-file-datalake-samples-js",
+  "name": "@azure-samples/storage-file-datalake-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Data Lake Storage client library samples for JavaScript",

--- a/sdk/storage/storage-file-datalake/samples/v12/javascript/package.json
+++ b/sdk/storage/storage-file-datalake/samples/v12/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-storage-file-datalake-samples-js",
+  "name": "@azure-samples/storage-file-datalake-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Data Lake Storage client library samples for JavaScript",

--- a/sdk/storage/storage-file-datalake/samples/v12/typescript/package.json
+++ b/sdk/storage/storage-file-datalake/samples/v12/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/storage-file-datalake-samples-ts",
+  "name": "@azure-samples/storage-file-datalake-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Data Lake Storage client library samples for TypeScript",

--- a/sdk/storage/storage-file-datalake/samples/v12/typescript/package.json
+++ b/sdk/storage/storage-file-datalake/samples/v12/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-storage-file-datalake-samples-ts",
+  "name": "@azure-samples/storage-file-datalake-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Data Lake Storage client library samples for TypeScript",

--- a/sdk/storage/storage-file-share/samples/v12/javascript/package.json
+++ b/sdk/storage/storage-file-share/samples/v12/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-storage-file-share-samples-js",
+  "name": "@azure-samples/storage-file-share-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Storage File Share client library samples for JavaScript",

--- a/sdk/storage/storage-file-share/samples/v12/javascript/package.json
+++ b/sdk/storage/storage-file-share/samples/v12/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/storage-file-share-samples-js",
+  "name": "@azure-samples/storage-file-share-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Storage File Share client library samples for JavaScript",

--- a/sdk/storage/storage-file-share/samples/v12/typescript/package.json
+++ b/sdk/storage/storage-file-share/samples/v12/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/storage-file-share-samples-ts",
+  "name": "@azure-samples/storage-file-share-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Storage File Share client library samples for TypeScript",

--- a/sdk/storage/storage-file-share/samples/v12/typescript/package.json
+++ b/sdk/storage/storage-file-share/samples/v12/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-storage-file-share-samples-ts",
+  "name": "@azure-samples/storage-file-share-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Storage File Share client library samples for TypeScript",

--- a/sdk/storage/storage-queue/samples/v12/javascript/package.json
+++ b/sdk/storage/storage-queue/samples/v12/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/storage-queue-samples-js",
+  "name": "@azure-samples/storage-queue-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Storage Queue client library samples for JavaScript",

--- a/sdk/storage/storage-queue/samples/v12/javascript/package.json
+++ b/sdk/storage/storage-queue/samples/v12/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-storage-queue-samples-js",
+  "name": "@azure-samples/storage-queue-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Storage Queue client library samples for JavaScript",

--- a/sdk/storage/storage-queue/samples/v12/typescript/package.json
+++ b/sdk/storage/storage-queue/samples/v12/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-storage-queue-samples-ts",
+  "name": "@azure-samples/storage-queue-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Storage Queue client library samples for TypeScript",

--- a/sdk/storage/storage-queue/samples/v12/typescript/package.json
+++ b/sdk/storage/storage-queue/samples/v12/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/storage-queue-samples-ts",
+  "name": "@azure-samples/storage-queue-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Storage Queue client library samples for TypeScript",

--- a/sdk/storagecache/arm-storagecache/samples/v5/javascript/package.json
+++ b/sdk/storagecache/arm-storagecache/samples/v5/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-storagecache-samples-js",
+  "name": "@azure-samples/arm-storagecache-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/storagecache/arm-storagecache/samples/v5/javascript/package.json
+++ b/sdk/storagecache/arm-storagecache/samples/v5/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-storagecache-samples-js",
+  "name": "@azure-samples/arm-storagecache-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/storagecache/arm-storagecache/samples/v5/typescript/package.json
+++ b/sdk/storagecache/arm-storagecache/samples/v5/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-storagecache-samples-ts",
+  "name": "@azure-samples/arm-storagecache-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/storagecache/arm-storagecache/samples/v5/typescript/package.json
+++ b/sdk/storagecache/arm-storagecache/samples/v5/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-storagecache-samples-ts",
+  "name": "@azure-samples/arm-storagecache-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/storageimportexport/arm-storageimportexport/samples/v2/javascript/package.json
+++ b/sdk/storageimportexport/arm-storageimportexport/samples/v2/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-storageimportexport-samples-js",
+  "name": "@azure-samples/arm-storageimportexport-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/storageimportexport/arm-storageimportexport/samples/v2/javascript/package.json
+++ b/sdk/storageimportexport/arm-storageimportexport/samples/v2/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-storageimportexport-samples-js",
+  "name": "@azure-samples/arm-storageimportexport-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/storageimportexport/arm-storageimportexport/samples/v2/typescript/package.json
+++ b/sdk/storageimportexport/arm-storageimportexport/samples/v2/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-storageimportexport-samples-ts",
+  "name": "@azure-samples/arm-storageimportexport-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/storageimportexport/arm-storageimportexport/samples/v2/typescript/package.json
+++ b/sdk/storageimportexport/arm-storageimportexport/samples/v2/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-storageimportexport-samples-ts",
+  "name": "@azure-samples/arm-storageimportexport-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/storagesync/arm-storagesync/samples/v9/javascript/package.json
+++ b/sdk/storagesync/arm-storagesync/samples/v9/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-storagesync-samples-js",
+  "name": "@azure-samples/arm-storagesync-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/storagesync/arm-storagesync/samples/v9/javascript/package.json
+++ b/sdk/storagesync/arm-storagesync/samples/v9/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-storagesync-samples-js",
+  "name": "@azure-samples/arm-storagesync-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/storagesync/arm-storagesync/samples/v9/typescript/package.json
+++ b/sdk/storagesync/arm-storagesync/samples/v9/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-storagesync-samples-ts",
+  "name": "@azure-samples/arm-storagesync-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/storagesync/arm-storagesync/samples/v9/typescript/package.json
+++ b/sdk/storagesync/arm-storagesync/samples/v9/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-storagesync-samples-ts",
+  "name": "@azure-samples/arm-storagesync-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/storsimple1200series/arm-storsimple1200series/samples/v2/javascript/package.json
+++ b/sdk/storsimple1200series/arm-storsimple1200series/samples/v2/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-storsimple1200series-samples-js",
+  "name": "@azure-samples/arm-storsimple1200series-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/storsimple1200series/arm-storsimple1200series/samples/v2/javascript/package.json
+++ b/sdk/storsimple1200series/arm-storsimple1200series/samples/v2/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-storsimple1200series-samples-js",
+  "name": "@azure-samples/arm-storsimple1200series-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/storsimple1200series/arm-storsimple1200series/samples/v2/typescript/package.json
+++ b/sdk/storsimple1200series/arm-storsimple1200series/samples/v2/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-storsimple1200series-samples-ts",
+  "name": "@azure-samples/arm-storsimple1200series-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/storsimple1200series/arm-storsimple1200series/samples/v2/typescript/package.json
+++ b/sdk/storsimple1200series/arm-storsimple1200series/samples/v2/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-storsimple1200series-samples-ts",
+  "name": "@azure-samples/arm-storsimple1200series-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/storsimple8000series/arm-storsimple8000series/samples/v2/javascript/package.json
+++ b/sdk/storsimple8000series/arm-storsimple8000series/samples/v2/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-storsimple8000series-samples-js",
+  "name": "@azure-samples/arm-storsimple8000series-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/storsimple8000series/arm-storsimple8000series/samples/v2/javascript/package.json
+++ b/sdk/storsimple8000series/arm-storsimple8000series/samples/v2/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-storsimple8000series-samples-js",
+  "name": "@azure-samples/arm-storsimple8000series-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/storsimple8000series/arm-storsimple8000series/samples/v2/typescript/package.json
+++ b/sdk/storsimple8000series/arm-storsimple8000series/samples/v2/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-storsimple8000series-samples-ts",
+  "name": "@azure-samples/arm-storsimple8000series-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/storsimple8000series/arm-storsimple8000series/samples/v2/typescript/package.json
+++ b/sdk/storsimple8000series/arm-storsimple8000series/samples/v2/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-storsimple8000series-samples-ts",
+  "name": "@azure-samples/arm-storsimple8000series-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/support/arm-support/samples/v2/javascript/package.json
+++ b/sdk/support/arm-support/samples/v2/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-support-samples-js",
+  "name": "@azure-samples/arm-support-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/support/arm-support/samples/v2/javascript/package.json
+++ b/sdk/support/arm-support/samples/v2/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-support-samples-js",
+  "name": "@azure-samples/arm-support-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/support/arm-support/samples/v2/typescript/package.json
+++ b/sdk/support/arm-support/samples/v2/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-support-samples-ts",
+  "name": "@azure-samples/arm-support-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/support/arm-support/samples/v2/typescript/package.json
+++ b/sdk/support/arm-support/samples/v2/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-support-samples-ts",
+  "name": "@azure-samples/arm-support-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/synapse/synapse-access-control-rest/samples/v1/javascript/package.json
+++ b/sdk/synapse/synapse-access-control-rest/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-synapse-access-control-samples-js",
+  "name": "@azure-samples/synapse-access-control-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Synapse Access Control Rest client library samples for JavaScript",

--- a/sdk/synapse/synapse-access-control-rest/samples/v1/javascript/package.json
+++ b/sdk/synapse/synapse-access-control-rest/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/synapse-access-control-samples-js",
+  "name": "@azure-samples/synapse-access-control-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Synapse Access Control Rest client library samples for JavaScript",

--- a/sdk/synapse/synapse-access-control-rest/samples/v1/typescript/package.json
+++ b/sdk/synapse/synapse-access-control-rest/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-synapse-access-control-samples-ts",
+  "name": "@azure-samples/synapse-access-control-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Synapse Access Control Rest client library samples for TypeScript",

--- a/sdk/synapse/synapse-access-control-rest/samples/v1/typescript/package.json
+++ b/sdk/synapse/synapse-access-control-rest/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/synapse-access-control-samples-ts",
+  "name": "@azure-samples/synapse-access-control-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Synapse Access Control Rest client library samples for TypeScript",

--- a/sdk/tables/data-tables/samples/v12/javascript/package.json
+++ b/sdk/tables/data-tables/samples/v12/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/data-tables-samples-js",
+  "name": "@azure-samples/data-tables-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Data Tables client library samples for JavaScript",

--- a/sdk/tables/data-tables/samples/v12/javascript/package.json
+++ b/sdk/tables/data-tables/samples/v12/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-data-tables-samples-js",
+  "name": "@azure-samples/data-tables-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Data Tables client library samples for JavaScript",

--- a/sdk/tables/data-tables/samples/v12/typescript/package.json
+++ b/sdk/tables/data-tables/samples/v12/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-data-tables-samples-ts",
+  "name": "@azure-samples/data-tables-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Data Tables client library samples for TypeScript",

--- a/sdk/tables/data-tables/samples/v12/typescript/package.json
+++ b/sdk/tables/data-tables/samples/v12/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/data-tables-samples-ts",
+  "name": "@azure-samples/data-tables-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Data Tables client library samples for TypeScript",

--- a/sdk/tables/data-tables/samples/v13/javascript/package.json
+++ b/sdk/tables/data-tables/samples/v13/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/data-tables-samples-js",
+  "name": "@azure-samples/data-tables-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Data Tables client library samples for JavaScript",

--- a/sdk/tables/data-tables/samples/v13/javascript/package.json
+++ b/sdk/tables/data-tables/samples/v13/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-data-tables-samples-js",
+  "name": "@azure-samples/data-tables-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Data Tables client library samples for JavaScript",

--- a/sdk/tables/data-tables/samples/v13/typescript/package.json
+++ b/sdk/tables/data-tables/samples/v13/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-data-tables-samples-ts",
+  "name": "@azure-samples/data-tables-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Data Tables client library samples for TypeScript",

--- a/sdk/tables/data-tables/samples/v13/typescript/package.json
+++ b/sdk/tables/data-tables/samples/v13/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/data-tables-samples-ts",
+  "name": "@azure-samples/data-tables-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Data Tables client library samples for TypeScript",

--- a/sdk/template/template/samples/v1-beta/javascript/package.json
+++ b/sdk/template/template/samples/v1-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/template-samples-js-beta",
+  "name": "@azure-samples/template-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Template client library samples for JavaScript (Beta)",

--- a/sdk/template/template/samples/v1-beta/javascript/package.json
+++ b/sdk/template/template/samples/v1-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-template-samples-js-beta",
+  "name": "@azure-samples/template-samples-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Template client library samples for JavaScript (Beta)",

--- a/sdk/template/template/samples/v1-beta/typescript/package.json
+++ b/sdk/template/template/samples/v1-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/template-samples-ts-beta",
+  "name": "@azure-samples/template-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Template client library samples for TypeScript (Beta)",

--- a/sdk/template/template/samples/v1-beta/typescript/package.json
+++ b/sdk/template/template/samples/v1-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-template-samples-ts-beta",
+  "name": "@azure-samples/template-samples-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Template client library samples for TypeScript (Beta)",

--- a/sdk/textanalytics/ai-text-analytics/samples/v5/javascript/package.json
+++ b/sdk/textanalytics/ai-text-analytics/samples/v5/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-ai-text-analytics-samples-js",
+  "name": "@azure-samples/ai-text-analytics-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Text Analytics client library samples for JavaScript",

--- a/sdk/textanalytics/ai-text-analytics/samples/v5/javascript/package.json
+++ b/sdk/textanalytics/ai-text-analytics/samples/v5/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/ai-text-analytics-samples-js",
+  "name": "@azure-samples/ai-text-analytics-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Text Analytics client library samples for JavaScript",

--- a/sdk/textanalytics/ai-text-analytics/samples/v5/typescript/package.json
+++ b/sdk/textanalytics/ai-text-analytics/samples/v5/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/ai-text-analytics-samples-ts",
+  "name": "@azure-samples/ai-text-analytics-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Text Analytics client library samples for TypeScript",

--- a/sdk/textanalytics/ai-text-analytics/samples/v5/typescript/package.json
+++ b/sdk/textanalytics/ai-text-analytics/samples/v5/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-ai-text-analytics-samples-ts",
+  "name": "@azure-samples/ai-text-analytics-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Text Analytics client library samples for TypeScript",

--- a/sdk/trafficmanager/arm-trafficmanager/samples/v6/javascript/package.json
+++ b/sdk/trafficmanager/arm-trafficmanager/samples/v6/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-trafficmanager-samples-js",
+  "name": "@azure-samples/arm-trafficmanager-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/trafficmanager/arm-trafficmanager/samples/v6/javascript/package.json
+++ b/sdk/trafficmanager/arm-trafficmanager/samples/v6/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-trafficmanager-samples-js",
+  "name": "@azure-samples/arm-trafficmanager-js",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript",

--- a/sdk/trafficmanager/arm-trafficmanager/samples/v6/typescript/package.json
+++ b/sdk/trafficmanager/arm-trafficmanager/samples/v6/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-trafficmanager-samples-ts",
+  "name": "@azure-samples/arm-trafficmanager-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/trafficmanager/arm-trafficmanager/samples/v6/typescript/package.json
+++ b/sdk/trafficmanager/arm-trafficmanager/samples/v6/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-trafficmanager-samples-ts",
+  "name": "@azure-samples/arm-trafficmanager-ts",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript",

--- a/sdk/videoanalyzer/video-analyzer-edge/samples/v1/javascript/package.json
+++ b/sdk/videoanalyzer/video-analyzer-edge/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-video-analyzer-edge-samples-js",
+  "name": "@azure-samples/video-analyzer-edge-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Video Analyzer client library samples for JavaScript",

--- a/sdk/videoanalyzer/video-analyzer-edge/samples/v1/javascript/package.json
+++ b/sdk/videoanalyzer/video-analyzer-edge/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/video-analyzer-edge-samples-js",
+  "name": "@azure-samples/video-analyzer-edge-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Video Analyzer client library samples for JavaScript",

--- a/sdk/videoanalyzer/video-analyzer-edge/samples/v1/typescript/package.json
+++ b/sdk/videoanalyzer/video-analyzer-edge/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/video-analyzer-edge-samples-ts",
+  "name": "@azure-samples/video-analyzer-edge-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Video Analyzer client library samples for TypeScript",

--- a/sdk/videoanalyzer/video-analyzer-edge/samples/v1/typescript/package.json
+++ b/sdk/videoanalyzer/video-analyzer-edge/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-video-analyzer-edge-samples-ts",
+  "name": "@azure-samples/video-analyzer-edge-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Video Analyzer client library samples for TypeScript",

--- a/sdk/visualstudio/arm-visualstudio/samples/v4-beta/javascript/package.json
+++ b/sdk/visualstudio/arm-visualstudio/samples/v4-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-visualstudio-samples-js-beta",
+  "name": "@azure-samples/arm-visualstudio-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/visualstudio/arm-visualstudio/samples/v4-beta/javascript/package.json
+++ b/sdk/visualstudio/arm-visualstudio/samples/v4-beta/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-visualstudio-samples-js-beta",
+  "name": "@azure-samples/arm-visualstudio-samples-js-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for JavaScript (Beta)",

--- a/sdk/visualstudio/arm-visualstudio/samples/v4-beta/typescript/package.json
+++ b/sdk/visualstudio/arm-visualstudio/samples/v4-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-arm-visualstudio-samples-ts-beta",
+  "name": "@azure-samples/arm-visualstudio-samples-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/visualstudio/arm-visualstudio/samples/v4-beta/typescript/package.json
+++ b/sdk/visualstudio/arm-visualstudio/samples/v4-beta/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/arm-visualstudio-samples-ts-beta",
+  "name": "@azure-samples/arm-visualstudio-ts-beta",
   "private": true,
   "version": "1.0.0",
   "description": " client library samples for TypeScript (Beta)",

--- a/sdk/web-pubsub/web-pubsub-express/samples/v1/javascript/package.json
+++ b/sdk/web-pubsub/web-pubsub-express/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-web-pubsub-express-samples-js",
+  "name": "@azure-samples/web-pubsub-express-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Web PubSub CloudEvents Handlers for Express client library samples for JavaScript",

--- a/sdk/web-pubsub/web-pubsub-express/samples/v1/javascript/package.json
+++ b/sdk/web-pubsub/web-pubsub-express/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/web-pubsub-express-samples-js",
+  "name": "@azure-samples/web-pubsub-express-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Web PubSub CloudEvents Handlers for Express client library samples for JavaScript",

--- a/sdk/web-pubsub/web-pubsub-express/samples/v1/typescript/package.json
+++ b/sdk/web-pubsub/web-pubsub-express/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/web-pubsub-express-samples-ts",
+  "name": "@azure-samples/web-pubsub-express-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Web PubSub CloudEvents Handlers for Express client library samples for TypeScript",

--- a/sdk/web-pubsub/web-pubsub-express/samples/v1/typescript/package.json
+++ b/sdk/web-pubsub/web-pubsub-express/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-web-pubsub-express-samples-ts",
+  "name": "@azure-samples/web-pubsub-express-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Web PubSub CloudEvents Handlers for Express client library samples for TypeScript",

--- a/sdk/web-pubsub/web-pubsub/samples/v1/javascript/package.json
+++ b/sdk/web-pubsub/web-pubsub/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/web-pubsub-samples-js",
+  "name": "@azure-samples/web-pubsub-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Web PubSub client library samples for JavaScript",

--- a/sdk/web-pubsub/web-pubsub/samples/v1/javascript/package.json
+++ b/sdk/web-pubsub/web-pubsub/samples/v1/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-web-pubsub-samples-js",
+  "name": "@azure-samples/web-pubsub-samples-js",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Web PubSub client library samples for JavaScript",

--- a/sdk/web-pubsub/web-pubsub/samples/v1/typescript/package.json
+++ b/sdk/web-pubsub/web-pubsub/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-web-pubsub-samples-ts",
+  "name": "@azure-samples/web-pubsub-samples-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Web PubSub client library samples for TypeScript",

--- a/sdk/web-pubsub/web-pubsub/samples/v1/typescript/package.json
+++ b/sdk/web-pubsub/web-pubsub/samples/v1/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azure-samples/web-pubsub-samples-ts",
+  "name": "@azure-samples/web-pubsub-ts",
   "private": true,
   "version": "1.0.0",
   "description": "Azure Web PubSub client library samples for TypeScript",


### PR DESCRIPTION
This PR renames all sample packages mechanically to use an `@azure-samples` NPM namespace. It also updates the name that is generated by dev-tool to use the same format.